### PR TITLE
Center OrientationWarning overlay on screen

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/OrientationWarning/OrientationWarning.css
+++ b/src/app/components/DoubleSlitExperiment/components/OrientationWarning/OrientationWarning.css
@@ -1,10 +1,9 @@
 /* Stili del componente OrientationWarning da sostituire */
 .orientation-warning {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     width: 100vw;
     height: 100vh;
     background-color: #000000;
@@ -17,7 +16,6 @@
     margin: 0;
     overflow-y: auto;
     box-sizing: border-box;
-    min-height: 100vh;
 }
 
 .orientation-content {


### PR DESCRIPTION
Updated the .orientation-warning CSS to use absolute centering with transform, replacing the previous top/left/right/bottom positioning. Removed redundant min-height property for cleaner layout.