### PR TITLE
Improve 3D visuals: PBR materials, bloom, shadows, better lighting

### DIFF
--- a/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
+++ b/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
@@ -110,6 +110,7 @@ export default function DoubleSlitExperiment() {
     mountRef,
     sceneRef,
     rendererRef,
+    composerRef,
     cameraRef,
     controlsRef,
     detectionScreenRef,
@@ -201,6 +202,7 @@ export default function DoubleSlitExperiment() {
     scene: sceneRef.current,
     camera: cameraRef.current,
     renderer: rendererRef.current,
+    composer: composerRef.current,
     controls: controlsRef.current
   });
 
@@ -208,6 +210,7 @@ export default function DoubleSlitExperiment() {
     scene: sceneRef.current,
     camera: cameraRef.current,
     renderer: rendererRef.current,
+    composer: composerRef.current,
     controls: controlsRef.current,
     particleSystem: particleSystemRef.current,
     detectionScreen: detectionScreenRef.current,

--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -1,15 +1,54 @@
 import * as THREE from 'three';
 
-export const createExperimentSetup = (scene: THREE.Scene) => {
-  const cylinderGeometry = new THREE.CylinderGeometry(3.5, 3.5, 12, 32);
-  const cylinderMaterial = new THREE.MeshPhongMaterial({
-    color: 0xffffff,
-    emissive: 0x222222
+const createGenerator = (scene: THREE.Scene) => {
+  const generatorGroup = new THREE.Group();
+
+  const bodyGeometry = new THREE.CylinderGeometry(3.5, 3.5, 12, 48);
+  const bodyMaterial = new THREE.MeshStandardMaterial({
+    color: 0xd8dde6,
+    metalness: 0.85,
+    roughness: 0.3
   });
-  const cylinder = new THREE.Mesh(cylinderGeometry, cylinderMaterial);
-  cylinder.position.set(0, 0, -5);
-  cylinder.rotation.x = Math.PI / 2;
-  scene.add(cylinder);
+  const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
+  body.rotation.x = Math.PI / 2;
+  body.castShadow = true;
+  body.receiveShadow = true;
+  generatorGroup.add(body);
+
+  // Reinforcement rings along the barrel
+  const ringMaterial = new THREE.MeshStandardMaterial({
+    color: 0x6b7484,
+    metalness: 0.9,
+    roughness: 0.35
+  });
+  [-4.5, -1.5, 1.5, 4.5].forEach(offset => {
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(3.55, 0.18, 16, 64), ringMaterial);
+    ring.position.z = offset;
+    ring.castShadow = true;
+    generatorGroup.add(ring);
+  });
+
+  // Glowing emitter aperture on the muzzle
+  const apertureGeometry = new THREE.CircleGeometry(1.2, 48);
+  const apertureMaterial = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(0x77bbff).multiplyScalar(1.6)
+  });
+  const aperture = new THREE.Mesh(apertureGeometry, apertureMaterial);
+  aperture.position.z = 6.01;
+  generatorGroup.add(aperture);
+
+  const apertureRimGeometry = new THREE.TorusGeometry(1.35, 0.12, 16, 48);
+  const apertureRim = new THREE.Mesh(apertureRimGeometry, ringMaterial);
+  apertureRim.position.z = 6.0;
+  generatorGroup.add(apertureRim);
+
+  generatorGroup.position.set(0, 0, -5);
+  scene.add(generatorGroup);
+  return generatorGroup;
+};
+
+export const createExperimentSetup = (scene: THREE.Scene) => {
+  createGenerator(scene);
 
   // Detection screen (main, front layer)
   const screenGeometry = new THREE.PlaneGeometry(20, 15);
@@ -26,67 +65,112 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
 
   // Detection screen back (background layer)
   const backGeometry = new THREE.PlaneGeometry(20, 15);
-  const backMaterial = new THREE.MeshBasicMaterial({
-    color: 0x333333,
+  const backMaterial = new THREE.MeshStandardMaterial({
+    color: 0x30343c,
+    metalness: 0.1,
+    roughness: 0.85,
     side: THREE.DoubleSide
   });
   const detectionScreenBack = new THREE.Mesh(backGeometry, backMaterial);
   detectionScreenBack.position.set(0, 0, 30.1);
   detectionScreenBack.rotation.x = 0;
+  detectionScreenBack.receiveShadow = true;
   scene.add(detectionScreenBack);
 
+  // Metallic frame around the detection screen
+  const screenFrameMaterial = new THREE.MeshStandardMaterial({
+    color: 0x555e6e,
+    metalness: 0.7,
+    roughness: 0.55
+  });
+  const screenFrame = new THREE.Group();
+  const frameThickness = 0.5;
+  const frameDepth = 0.6;
+  const horizontalBar = new THREE.BoxGeometry(20 + frameThickness * 2, frameThickness, frameDepth);
+  const verticalBar = new THREE.BoxGeometry(frameThickness, 15, frameDepth);
+  const framePieces: Array<[THREE.BoxGeometry, number, number]> = [
+    [horizontalBar, 0, 7.5 + frameThickness / 2],
+    [horizontalBar, 0, -7.5 - frameThickness / 2],
+    [verticalBar, 10 + frameThickness / 2, 0],
+    [verticalBar, -10 - frameThickness / 2, 0]
+  ];
+  framePieces.forEach(([geometry, x, y]) => {
+    const bar = new THREE.Mesh(geometry, screenFrameMaterial);
+    bar.position.set(x, y, 30.1);
+    bar.castShadow = true;
+    bar.receiveShadow = true;
+    screenFrame.add(bar);
+  });
+  scene.add(screenFrame);
+
   const diffractionPanelGroup = new THREE.Group();
-  const diffractionPanelMaterial = new THREE.MeshBasicMaterial({
-    color: 0x666666,
+  const diffractionPanelMaterial = new THREE.MeshStandardMaterial({
+    color: 0x7b828f,
+    metalness: 0.65,
+    roughness: 0.45,
     side: THREE.DoubleSide
   });
+  const panelDepth = 0.35;
 
-  const topGeometry = new THREE.PlaneGeometry(20, 5.5);
-  const topDiffractionPanel = new THREE.Mesh(topGeometry, diffractionPanelMaterial);
-  topDiffractionPanel.position.set(0, 4.75, 15);
-  topDiffractionPanel.rotation.y = Math.PI;
-  diffractionPanelGroup.add(topDiffractionPanel);
+  const addPanel = (width: number, height: number, x: number, y: number) => {
+    const geometry = new THREE.BoxGeometry(width, height, panelDepth);
+    const panel = new THREE.Mesh(geometry, diffractionPanelMaterial);
+    panel.position.set(x, y, 15);
+    panel.castShadow = true;
+    panel.receiveShadow = true;
+    diffractionPanelGroup.add(panel);
+    return panel;
+  };
 
-  const bottomGeometry = new THREE.PlaneGeometry(20, 5.5);
-  const bottomDiffractionPanel = new THREE.Mesh(bottomGeometry, diffractionPanelMaterial);
-  bottomDiffractionPanel.position.set(0, -4.75, 15);
-  bottomDiffractionPanel.rotation.y = Math.PI;
-  diffractionPanelGroup.add(bottomDiffractionPanel);
+  addPanel(20, 5.5, 0, 4.75);
+  addPanel(20, 5.5, 0, -4.75);
+  addPanel(8.5, 4, -5.75, 0);
+  addPanel(1, 4, 0, 0);
+  addPanel(8.5, 4, 5.75, 0);
 
-  const leftGeometry = new THREE.PlaneGeometry(8.5, 4);
-  const leftDiffractionPanel = new THREE.Mesh(leftGeometry, diffractionPanelMaterial);
-  leftDiffractionPanel.position.set(-5.75, 0, 15);
-  leftDiffractionPanel.rotation.y = Math.PI;
-  diffractionPanelGroup.add(leftDiffractionPanel);
-
-  const middleGeometry = new THREE.PlaneGeometry(1, 4);
-  const middleDiffractionPanel = new THREE.Mesh(middleGeometry, diffractionPanelMaterial);
-  middleDiffractionPanel.position.set(0, 0, 15);
-  middleDiffractionPanel.rotation.y = Math.PI;
-  diffractionPanelGroup.add(middleDiffractionPanel);
-
-  const rightGeometry = new THREE.PlaneGeometry(8.5, 4);
-  const rightDiffractionPanel = new THREE.Mesh(rightGeometry, diffractionPanelMaterial);
-  rightDiffractionPanel.position.set(5.75, 0, 15);
-  rightDiffractionPanel.rotation.y = Math.PI;
-  diffractionPanelGroup.add(rightDiffractionPanel);
+  // Emissive edging that outlines the two slits
+  const slitEdgeMaterial = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(0x55aaff).multiplyScalar(1.4)
+  });
+  [-1, 1].forEach(slitCenterX => {
+    const slitFrame = new THREE.Group();
+    const edgeSize = 0.06;
+    const verticalEdge = new THREE.BoxGeometry(edgeSize, 4, panelDepth + 0.02);
+    const horizontalEdge = new THREE.BoxGeometry(1 + edgeSize * 2, edgeSize, panelDepth + 0.02);
+    const edges: Array<[THREE.BoxGeometry, number, number]> = [
+      [verticalEdge, -0.5 - edgeSize / 2, 0],
+      [verticalEdge, 0.5 + edgeSize / 2, 0],
+      [horizontalEdge, 0, 2 + edgeSize / 2],
+      [horizontalEdge, 0, -2 - edgeSize / 2]
+    ];
+    edges.forEach(([geometry, x, y]) => {
+      const edge = new THREE.Mesh(geometry, slitEdgeMaterial);
+      edge.position.set(x, y, 0);
+      slitFrame.add(edge);
+    });
+    slitFrame.position.set(slitCenterX, 0, 15);
+    diffractionPanelGroup.add(slitFrame);
+  });
 
   scene.add(diffractionPanelGroup);
 
   const beamRadius = 2.5;
   const beamLength = 15;
-  const beamGeometry = new THREE.CylinderGeometry(beamRadius, beamRadius, beamLength, 32, 1, true);
+  const beamGeometry = new THREE.CylinderGeometry(beamRadius, beamRadius, beamLength, 48, 1, true);
   const beamMaterial = new THREE.MeshBasicMaterial({
-    color: 0x00ff00,
+    color: 0x33ff77,
     transparent: true,
-    opacity: 0.3,
-    side: THREE.DoubleSide
+    opacity: 0.22,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false
   });
   const lightBeam = new THREE.Mesh(beamGeometry, beamMaterial);
 
   lightBeam.position.set(0, 0, beamLength / 2);
   lightBeam.rotation.x = Math.PI / 2;
   lightBeam.visible = false;
+  lightBeam.renderOrder = 1;
   scene.add(lightBeam);
 
   const createTrapezoidGeometry = (
@@ -128,22 +212,26 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
   };
 
   const trapezoidMaterial = new THREE.MeshBasicMaterial({
-    color: 0x00ff00,
+    color: 0x33ff77,
     transparent: true,
-    opacity: 0.3,
-    side: THREE.DoubleSide
+    opacity: 0.18,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false
   });
 
   const leftTrapezoidGeometry = createTrapezoidGeometry(1, 8, 4, 15);
   const leftTrapezoid = new THREE.Mesh(leftTrapezoidGeometry, trapezoidMaterial);
   leftTrapezoid.position.set(-1, 0, 15);
   leftTrapezoid.visible = false;
+  leftTrapezoid.renderOrder = 1;
   scene.add(leftTrapezoid);
 
   const rightTrapezoidGeometry = createTrapezoidGeometry(1, 8, 4, 15);
   const rightTrapezoid = new THREE.Mesh(rightTrapezoidGeometry, trapezoidMaterial);
   rightTrapezoid.position.set(1, 0, 15);
   rightTrapezoid.visible = false;
+  rightTrapezoid.renderOrder = 1;
   scene.add(rightTrapezoid);
 
   return { detectionScreen, detectionScreenBack, diffractionPanelGroup, lightBeam, leftTrapezoid, rightTrapezoid };

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -21,9 +21,10 @@ export class ParticleSystem {
   }
 
   createSingleProton() {
-    const geometry = new THREE.SphereGeometry(0.05, 8, 6);
+    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
-      color: 0xff0000,
+      color: new THREE.Color(0xff5533).multiplyScalar(2.5),
       transparent: false
     });
 
@@ -50,9 +51,10 @@ export class ParticleSystem {
   }
 
   createSingleElectron() {
-    const geometry = new THREE.SphereGeometry(0.05, 8, 6);
+    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
-      color: 0x0000ff,
+      color: new THREE.Color(0x3388ff).multiplyScalar(2.5),
       transparent: false
     });
 

--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -3,21 +3,24 @@ import * as THREE from 'three';
 const createTextLabel = (text: string): THREE.Group => {
   const labelGroup = new THREE.Group();
 
+  // Higher-resolution canvas keeps the text crisp when zooming in
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d')!;
-  canvas.width = 512;
-  canvas.height = 128;
+  canvas.width = 1024;
+  canvas.height = 256;
 
   context.fillStyle = 'rgba(0, 0, 0, 0)';
   context.fillRect(0, 0, canvas.width, canvas.height);
 
   context.fillStyle = 'white';
-  context.font = 'bold 36px Arial';
+  context.font = 'bold 72px Arial';
   context.textAlign = 'center';
   context.textBaseline = 'middle';
+  context.shadowColor = 'rgba(140, 190, 255, 0.85)';
+  context.shadowBlur = 16;
 
   const lines = text.split('\n');
-  const lineHeight = 45;
+  const lineHeight = 90;
   const startY = canvas.height / 2 - (lines.length - 1) * lineHeight / 2;
 
   lines.forEach((line, index) => {
@@ -25,6 +28,7 @@ const createTextLabel = (text: string): THREE.Group => {
   });
 
   const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = 4;
   texture.needsUpdate = true;
 
   const spriteMaterial = new THREE.SpriteMaterial({

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { ParticleSystem } from '../components/ParticleSystem';
 import { updateParticlePhysics } from '../utils/physicsSimulation';
 
@@ -8,6 +9,7 @@ interface AnimationProps {
   scene: THREE.Scene | null;
   camera: THREE.PerspectiveCamera | null;
   renderer: THREE.WebGLRenderer | null;
+  composer: EffectComposer | null;
   controls: OrbitControls | null;
   particleSystem: ParticleSystem | null;
   detectionScreen: THREE.Mesh | null;
@@ -18,6 +20,7 @@ export const useExperimentAnimation = ({
   scene,
   camera,
   renderer,
+  composer,
   controls,
   particleSystem,
   detectionScreen,
@@ -82,7 +85,11 @@ export const useExperimentAnimation = ({
         particleSystem.setParticles(updatedParticles);
       }
 
-      renderer.render(scene, camera);
+      if (composer) {
+        composer.render();
+      } else {
+        renderer.render(scene, camera);
+      }
     };
 
     animate();
@@ -92,5 +99,5 @@ export const useExperimentAnimation = ({
         cancelAnimationFrame(animationIdRef.current);
       }
     };
-  }, [scene, camera, renderer, controls, particleSystem, detectionScreen, activePhase]);
+  }, [scene, camera, renderer, composer, controls, particleSystem, detectionScreen, activePhase]);
 };

--- a/src/app/components/DoubleSlitExperiment/hooks/useResponsiveLayout.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useResponsiveLayout.ts
@@ -1,15 +1,17 @@
 import { useEffect } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 
 interface ResponsiveLayoutProps {
   scene: THREE.Scene | null;
   camera: THREE.PerspectiveCamera | null;
   renderer: THREE.WebGLRenderer | null;
+  composer: EffectComposer | null;
   controls: OrbitControls | null;
 }
 
-export const useResponsiveLayout = ({ scene, camera, renderer, controls }: ResponsiveLayoutProps) => {
+export const useResponsiveLayout = ({ scene, camera, renderer, composer, controls }: ResponsiveLayoutProps) => {
   useEffect(() => {
     if (!scene || !camera || !renderer || !controls) return;
 
@@ -32,6 +34,7 @@ export const useResponsiveLayout = ({ scene, camera, renderer, controls }: Respo
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
+      composer?.setSize(window.innerWidth, window.innerHeight);
 
       // Reset scene position first
       scene.position.y = 0;
@@ -55,5 +58,5 @@ export const useResponsiveLayout = ({ scene, camera, renderer, controls }: Respo
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [scene, camera, renderer, controls]);
+  }, [scene, camera, renderer, composer, controls]);
 };

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import { createExperimentSetup } from '../components/ExperimentSetup';
 import { createSceneLabels } from '../components/SceneLabels';
 import { ParticleSystem } from '../components/ParticleSystem';
@@ -8,26 +13,45 @@ import { ParticleSystem } from '../components/ParticleSystem';
 const createObserver = (scene: THREE.Scene): THREE.Group => {
   const observerGroup = new THREE.Group();
 
-  const sphereGeometry = new THREE.SphereGeometry(0.8, 16, 16);
-  const sphereMaterial = new THREE.MeshPhongMaterial({
-    color: 0xaaaaaa,
-    emissive: 0x333333
+  const sphereGeometry = new THREE.SphereGeometry(0.8, 32, 32);
+  const sphereMaterial = new THREE.MeshStandardMaterial({
+    color: 0xc2c9d6,
+    metalness: 0.8,
+    roughness: 0.25,
+    emissive: 0x1a2438,
+    emissiveIntensity: 0.5
   });
   const sphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
+  sphere.castShadow = true;
   observerGroup.add(sphere);
 
+  // Glowing "lens" aimed at the slits so the observer reads as a sensor
+  const eyeDirection = new THREE.Vector3(-3, 0, 1).normalize();
+  const eyeGeometry = new THREE.CircleGeometry(0.3, 24);
+  const eyeMaterial = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(0x66ffcc).multiplyScalar(2.2)
+  });
+  const eye = new THREE.Mesh(eyeGeometry, eyeMaterial);
+  eye.position.copy(eyeDirection.clone().multiplyScalar(0.82));
+  eye.lookAt(eyeDirection.clone().multiplyScalar(5));
+  observerGroup.add(eye);
+
   const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 128;
+  canvas.width = 1024;
+  canvas.height = 256;
   const context = canvas.getContext('2d')!;
 
   context.fillStyle = '#ffffff';
-  context.font = 'bold 36px Arial';
+  context.font = 'bold 72px Arial';
   context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.shadowColor = 'rgba(120, 200, 255, 0.9)';
+  context.shadowBlur = 18;
   context.fillText('Observer', canvas.width / 2, canvas.height / 2);
 
   const texture = new THREE.CanvasTexture(canvas);
-  const spriteMaterial = new THREE.SpriteMaterial({ map: texture });
+  texture.anisotropy = 4;
+  const spriteMaterial = new THREE.SpriteMaterial({ map: texture, transparent: true });
   const sprite = new THREE.Sprite(spriteMaterial);
   sprite.scale.set(6, 1.5, 1);
   sprite.position.set(0, 1.2, 0);
@@ -46,6 +70,7 @@ export const useThreeScene = () => {
   const mountRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const composerRef = useRef<EffectComposer | null>(null);
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
   const controlsRef = useRef<OrbitControls | null>(null);
   const detectionScreenRef = useRef<THREE.Mesh | null>(null);
@@ -57,48 +82,85 @@ export const useThreeScene = () => {
   const labelsRef = useRef<THREE.Group[]>([]);
   const particleSystemRef = useRef<ParticleSystem | null>(null);
   const observerRef = useRef<THREE.Group | null>(null);
-  const defaultScreenMaterialRef = useRef<THREE.Material | null>(null);
-  const stripeScreenMaterialRef = useRef<THREE.Material | null>(null);
 
   useEffect(() => {
     if (!mountRef.current) return;
 
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x1a1a1a);
+    scene.background = new THREE.Color(0x0b0e14);
+    scene.fog = new THREE.Fog(0x0b0e14, 70, 170);
     sceneRef.current = scene;
-    console.log('Three.js scene created:', scene);
 
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.set(-19.165995152477358, 9.637643699188821, 5.055107657476825);
     cameraRef.current = camera;
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.15;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     mountRef.current.appendChild(renderer.domElement);
     rendererRef.current = renderer;
 
-    const ambientLight = new THREE.AmbientLight(0x404040, 0.6);
-    scene.add(ambientLight);
+    // Image-based lighting so metallic PBR materials pick up soft reflections
+    const pmremGenerator = new THREE.PMREMGenerator(renderer);
+    scene.environment = pmremGenerator.fromScene(new RoomEnvironment(), 0.04).texture;
+    scene.environmentIntensity = 0.35;
+    pmremGenerator.dispose();
 
-    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
-    directionalLight.position.set(5, 5, 5);
-    scene.add(directionalLight);
+    const hemiLight = new THREE.HemisphereLight(0x8fa3c7, 0x1c2433, 0.5);
+    scene.add(hemiLight);
 
-    const pointLight = new THREE.PointLight(0x4444ff, 0.5, 20);
-    pointLight.position.set(0, 0, 5);
-    scene.add(pointLight);
+    const keyLight = new THREE.DirectionalLight(0xfff2e0, 2.0);
+    keyLight.position.set(-25, 30, 0);
+    keyLight.target.position.set(0, 0, 15);
+    keyLight.castShadow = true;
+    keyLight.shadow.mapSize.set(2048, 2048);
+    keyLight.shadow.camera.left = -45;
+    keyLight.shadow.camera.right = 45;
+    keyLight.shadow.camera.top = 45;
+    keyLight.shadow.camera.bottom = -45;
+    keyLight.shadow.camera.near = 1;
+    keyLight.shadow.camera.far = 120;
+    keyLight.shadow.bias = -0.0004;
+    scene.add(keyLight);
+    scene.add(keyLight.target);
+
+    const rimLight = new THREE.DirectionalLight(0x5f7dff, 0.45);
+    rimLight.position.set(22, 8, 42);
+    scene.add(rimLight);
+
+    const accentLight = new THREE.PointLight(0x4466ff, 22, 45, 2);
+    accentLight.position.set(0, 3, 8);
+    scene.add(accentLight);
+
+    const composer = new EffectComposer(renderer);
+    composer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    composer.setSize(window.innerWidth, window.innerHeight);
+    composer.addPass(new RenderPass(scene, camera));
+    const bloomPass = new UnrealBloomPass(
+      new THREE.Vector2(window.innerWidth, window.innerHeight),
+      0.55,
+      0.4,
+      0.6
+    );
+    composer.addPass(bloomPass);
+    composer.addPass(new OutputPass());
+    composerRef.current = composer;
 
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.target.set(1.6695085561159786, -3.0874538457220844, 16.502079563322997);
     controls.enablePan = true;
     controls.enableZoom = true;
     controls.enableRotate = true;
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.06;
     controls.minDistance = 1;
     controls.maxDistance = 60;
     controlsRef.current = controls;
-
-    console.log('Three.js setup complete - Camera:', camera.position, 'Target:', controls.target);
 
     const { detectionScreen, detectionScreenBack, diffractionPanelGroup, lightBeam, leftTrapezoid, rightTrapezoid } = createExperimentSetup(scene);
     detectionScreenRef.current = detectionScreen;
@@ -119,15 +181,13 @@ export const useThreeScene = () => {
 
     particleSystem.createInitialProtons(50);
 
-    console.log('Experiment setup complete, scene objects:', scene.children.length);
-    console.log('Initial particles created:', particleSystem.getParticleCount());
-
     setSceneReady(true);
 
     return () => {
       if (mountRef.current && rendererRef.current?.domElement) {
         mountRef.current.removeChild(rendererRef.current.domElement);
       }
+      composerRef.current?.dispose();
       rendererRef.current?.dispose();
     };
   }, []);
@@ -136,6 +196,7 @@ export const useThreeScene = () => {
     mountRef,
     sceneRef,
     rendererRef,
+    composerRef,
     cameraRef,
     controlsRef,
     detectionScreenRef,

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -40,7 +40,8 @@ export const updateParticlePhysics = (
         // Convert particle to detection mark (proton behavior)
         particle.position.z = 30;
         if (particle.material instanceof THREE.MeshBasicMaterial) {
-          particle.material.color.setHex(0xffffff);
+          // Slightly over-white HDR value so detection marks glow via bloom
+          particle.material.color.setRGB(1.6, 1.6, 1.5);
         }
         particle.userData.velocity.x = 0;
         particle.userData.velocity.y = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Graphical overhaul of the Three.js scene while keeping physics, phases, and camera framing untouched.

### Rendering pipeline (`useThreeScene.ts`)
- ACES Filmic tone mapping with tuned exposure, capped pixel ratio at 2 for performance
- Post-processing via `EffectComposer` + `UnrealBloomPass` + `OutputPass`, so bright/HDR elements glow
- PCF soft shadow mapping enabled
- Image-based lighting with `RoomEnvironment` (PMREM) so metallic PBR surfaces get soft reflections
- New lighting rig: warm key light with shadows, cool blue rim light, hemisphere fill, subtle blue accent point light
- Deep blue-black background with matching fog for depth
- OrbitControls damping for smoother camera movement

### Apparatus (`ExperimentSetup.ts`)
- Particle generator rebuilt as a detailed group: brushed-metal `MeshStandardMaterial` barrel, torus reinforcement rings, glowing emitter aperture with rim
- Diffraction panels converted from flat planes to boxes with thickness, metallic PBR material, and emissive blue edging outlining the two slits
- Detection screen got a metallic frame and a matte PBR backing that receives shadows
- Laser beam and diffraction cones now use additive blending (no depth-write) for a real light-volume look

### Particles & labels
- Protons/electrons use HDR colors (values above 1) so the bloom pass makes them glow red/blue; slightly larger and smoother spheres
- Detection marks use over-white HDR color so impacts glow on the screen
- Scene labels rendered at 2x canvas resolution with a soft blue halo; observer got a metallic body and a glowing lens facing the slits

### Screenshots

| Proton | Light Wave |
|---|---|
| [Proton phase](https://cursor.com/agents/bc-019f3498-4057-7c55-8e4b-a0e6311314cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase-proton.png) | [Light wave phase](https://cursor.com/agents/bc-019f3498-4057-7c55-8e4b-a0e6311314cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase-light-wave.png) |

| Electron | Observer |
|---|---|
| [Electron phase](https://cursor.com/agents/bc-019f3498-4057-7c55-8e4b-a0e6311314cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase-electron.png) | [Observer phase](https://cursor.com/agents/bc-019f3498-4057-7c55-8e4b-a0e6311314cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase-add-an-observer.png) |

### Verification
- `tsc --noEmit`, `eslint` (no new warnings), and `next build` all pass
- All four phases visually verified in headless Chromium with screenshots


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3498-4057-7c55-8e4b-a0e6311314cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3498-4057-7c55-8e4b-a0e6311314cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

