### PR TITLE
Fix invisible sprite boxes cutting through the laser beam

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -34,11 +34,17 @@ const createTextLabel = (text: string): THREE.Group => {
   const spriteMaterial = new THREE.SpriteMaterial({
     map: texture,
     transparent: true,
-    opacity: 0.9
+    opacity: 0.9,
+    // Without this the sprite's full quad (including fully transparent pixels)
+    // writes to the depth buffer and occludes the additive laser beam drawn
+    // afterwards, which shows up as invisible boxes cutting through the beam.
+    depthWrite: false
   });
 
   const sprite = new THREE.Sprite(spriteMaterial);
   sprite.scale.set(6, 1.5, 1);
+  // Draw labels after the beam/trapezoids (renderOrder 1) so text stays readable
+  sprite.renderOrder = 2;
   labelGroup.add(sprite);
 
   return labelGroup;

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -51,10 +51,11 @@ const createObserver = (scene: THREE.Scene): THREE.Group => {
 
   const texture = new THREE.CanvasTexture(canvas);
   texture.anisotropy = 4;
-  const spriteMaterial = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const spriteMaterial = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
   const sprite = new THREE.Sprite(spriteMaterial);
   sprite.scale.set(6, 1.5, 1);
   sprite.position.set(0, 1.2, 0);
+  sprite.renderOrder = 2;
 
   observerGroup.add(sprite);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the laser (lightwave phase) is enabled, the text labels ("Particle Generator", "Diffraction Slits", "Detection Screen", "Observer") show up as invisible/transparent rectangles that cut through the beam and its diffraction trapezoids.

## Cause

The label sprites use `SpriteMaterial` with `transparent: true` but keep the default `depthWrite: true`. This makes the sprite's full rectangular quad — including its fully transparent pixels — write into the depth buffer. The laser beam and trapezoids are additive-blended transparent meshes rendered afterwards (`renderOrder = 1`), so any beam fragment behind a label quad fails the depth test and is discarded, leaving a rectangular "hole" in the beam wherever a label overlaps it.

## Fix

- Set `depthWrite: false` on the label sprite materials in `SceneLabels.ts` and on the Observer sprite in `useThreeScene.ts`, so their transparent quads no longer occlude geometry rendered behind/after them.
- Set `renderOrder = 2` on the sprites so the text is drawn after the beam (renderOrder 1) and stays readable on top of it.

## Verification

`tsc --noEmit` and `next lint` pass with no new warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34b1-c4ee-7a40-99ee-05544f7d274c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34b1-c4ee-7a40-99ee-05544f7d274c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

