### PR TITLE
Reduce glow on 3D scene text labels

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -16,8 +16,9 @@ const createTextLabel = (text: string): THREE.Group => {
   context.font = 'bold 72px Arial';
   context.textAlign = 'center';
   context.textBaseline = 'middle';
-  context.shadowColor = 'rgba(140, 190, 255, 0.85)';
-  context.shadowBlur = 16;
+  // Subtle halo only, so labels stay readable without glowing
+  context.shadowColor = 'rgba(140, 190, 255, 0.35)';
+  context.shadowBlur = 6;
 
   const lines = text.split('\n');
   const lineHeight = 90;
@@ -34,7 +35,9 @@ const createTextLabel = (text: string): THREE.Group => {
   const spriteMaterial = new THREE.SpriteMaterial({
     map: texture,
     transparent: true,
-    opacity: 0.9
+    opacity: 0.9,
+    // Keep label luminance below the bloom threshold so text doesn't glow
+    color: 0xb9c1cf
   });
 
   const sprite = new THREE.Sprite(spriteMaterial);

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -45,13 +45,20 @@ const createObserver = (scene: THREE.Scene): THREE.Group => {
   context.font = 'bold 72px Arial';
   context.textAlign = 'center';
   context.textBaseline = 'middle';
-  context.shadowColor = 'rgba(120, 200, 255, 0.9)';
-  context.shadowBlur = 18;
+  // Subtle halo only, so the label stays readable without glowing
+  context.shadowColor = 'rgba(120, 200, 255, 0.35)';
+  context.shadowBlur = 6;
   context.fillText('Observer', canvas.width / 2, canvas.height / 2);
 
   const texture = new THREE.CanvasTexture(canvas);
   texture.anisotropy = 4;
-  const spriteMaterial = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const spriteMaterial = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    opacity: 0.9,
+    // Keep label luminance below the bloom threshold so text doesn't glow
+    color: 0xb9c1cf
+  });
   const sprite = new THREE.Sprite(spriteMaterial);
   sprite.scale.set(6, 1.5, 1);
   sprite.position.set(0, 1.2, 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The text labels in the 3D scene ("Proton Accelerator", "Diffraction Slits", "Detection Screen", "Observer") were glowing too much: the pure-white sprites exceeded the bloom pass threshold, and the canvas text was drawn with a strong blue shadow halo.

Changes in `SceneLabels.ts` and the Observer label in `useThreeScene.ts`:
- Reduced the canvas text shadow from blur 16–18 / alpha 0.85–0.9 to blur 6 / alpha 0.35, keeping just a subtle halo for readability.
- Tinted the sprite materials to `0xb9c1cf` (and set opacity 0.9 on the Observer label) so the label luminance stays below the bloom threshold and the text no longer blooms.

## Before / After

| Before | After |
| --- | --- |
| [Before: glowing labels](https://cursor.com/agents/bc-019f34ad-fad1-75ce-b8b0-8e1fba22e055/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flabels-before.png) | [After: clean labels](https://cursor.com/agents/bc-019f34ad-fad1-75ce-b8b0-8e1fba22e055/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flabels-after.png) |

## Testing

- `npx tsc --noEmit` and `npm run lint` pass (only pre-existing warnings).
- Verified visually with headless Chrome screenshots of the running app (see above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34ad-fad1-75ce-b8b0-8e1fba22e055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34ad-fad1-75ce-b8b0-8e1fba22e055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

