### PR TITLE
Reduce electron gun reflectivity

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -6,8 +6,8 @@ const createGenerator = (scene: THREE.Scene) => {
   const bodyGeometry = new THREE.CylinderGeometry(3.5, 3.5, 12, 48);
   const bodyMaterial = new THREE.MeshStandardMaterial({
     color: 0xd8dde6,
-    metalness: 0.85,
-    roughness: 0.3
+    metalness: 0.6,
+    roughness: 0.5
   });
   const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
   body.rotation.x = Math.PI / 2;
@@ -18,8 +18,8 @@ const createGenerator = (scene: THREE.Scene) => {
   // Reinforcement rings along the barrel
   const ringMaterial = new THREE.MeshStandardMaterial({
     color: 0x6b7484,
-    metalness: 0.9,
-    roughness: 0.35
+    metalness: 0.65,
+    roughness: 0.55
   });
   [-4.5, -1.5, 1.5, 4.5].forEach(offset => {
     const ring = new THREE.Mesh(new THREE.TorusGeometry(3.55, 0.18, 16, 64), ringMaterial);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The electron gun was reflecting too much light. This PR tones down the reflective properties of its materials in `ExperimentSetup.ts`:

- Gun body: `metalness` 0.85 → 0.6, `roughness` 0.3 → 0.5
- Reinforcement rings and aperture rim: `metalness` 0.9 → 0.65, `roughness` 0.35 → 0.55

Higher roughness scatters specular highlights and lower metalness reduces mirror-like reflections, giving the gun a more matte metallic look.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34bf-6c1f-7d8e-8edc-4c460dc2bbcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34bf-6c1f-7d8e-8edc-4c460dc2bbcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

