### PR TITLE
Improve scene background: gradient dome, twinkling stars, grid floor

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
@@ -1,0 +1,142 @@
+import * as THREE from 'three';
+
+const createGradientDome = (): THREE.Mesh => {
+  const geometry = new THREE.SphereGeometry(400, 32, 24);
+  const material = new THREE.ShaderMaterial({
+    side: THREE.BackSide,
+    depthWrite: false,
+    uniforms: {
+      uTopColor: { value: new THREE.Color(0x060a14) },
+      uHorizonColor: { value: new THREE.Color(0x0e1526) },
+      uBottomColor: { value: new THREE.Color(0x04060c) }
+    },
+    vertexShader: `
+      varying vec3 vWorldPosition;
+      void main() {
+        vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+        vWorldPosition = worldPosition.xyz;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      uniform vec3 uTopColor;
+      uniform vec3 uHorizonColor;
+      uniform vec3 uBottomColor;
+      varying vec3 vWorldPosition;
+      void main() {
+        float h = normalize(vWorldPosition).y;
+        // Soft band around the horizon, fading toward zenith and nadir
+        vec3 color = mix(uHorizonColor, uTopColor, smoothstep(0.0, 0.55, h));
+        color = mix(uBottomColor, color, smoothstep(-0.35, 0.05, h));
+        gl_FragColor = vec4(color, 1.0);
+      }
+    `
+  });
+
+  const dome = new THREE.Mesh(geometry, material);
+  // Rendered first so everything else draws on top without depth issues
+  dome.renderOrder = -2;
+  return dome;
+};
+
+const createStarField = (): THREE.Points => {
+  const starCount = 700;
+  const positions = new Float32Array(starCount * 3);
+  const phases = new Float32Array(starCount);
+  const sizes = new Float32Array(starCount);
+
+  for (let i = 0; i < starCount; i++) {
+    // Random direction, kept above the horizon so stars never clash with the floor
+    const theta = Math.random() * Math.PI * 2;
+    const y = 0.06 + Math.random() * 0.94;
+    const horizontal = Math.sqrt(1 - y * y);
+    const radius = 240 + Math.random() * 130;
+
+    positions[i * 3] = Math.cos(theta) * horizontal * radius;
+    positions[i * 3 + 1] = y * radius;
+    positions[i * 3 + 2] = Math.sin(theta) * horizontal * radius;
+
+    phases[i] = Math.random() * Math.PI * 2;
+    sizes[i] = 0.9 + Math.random() * 2.1;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('aPhase', new THREE.BufferAttribute(phases, 1));
+  geometry.setAttribute('aSize', new THREE.BufferAttribute(sizes, 1));
+
+  const material = new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    uniforms: {
+      uTime: { value: 0 }
+    },
+    vertexShader: `
+      attribute float aPhase;
+      attribute float aSize;
+      uniform float uTime;
+      varying float vTwinkle;
+      void main() {
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        vTwinkle = 0.6 + 0.4 * sin(uTime * 0.9 + aPhase);
+        gl_PointSize = aSize * vTwinkle * (320.0 / -mvPosition.z);
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `,
+    fragmentShader: `
+      varying float vTwinkle;
+      void main() {
+        float d = length(gl_PointCoord - 0.5);
+        float alpha = smoothstep(0.5, 0.0, d) * vTwinkle;
+        gl_FragColor = vec4(vec3(0.72, 0.82, 1.0), alpha * 0.85);
+      }
+    `
+  });
+
+  const stars = new THREE.Points(geometry, material);
+  stars.renderOrder = -1;
+  stars.onBeforeRender = () => {
+    material.uniforms.uTime.value = performance.now() / 1000;
+  };
+  return stars;
+};
+
+const createFloor = (): THREE.Group => {
+  const floorGroup = new THREE.Group();
+  const floorY = -7.6;
+
+  const floorGeometry = new THREE.CircleGeometry(150, 64);
+  const floorMaterial = new THREE.MeshStandardMaterial({
+    color: 0x0c1018,
+    metalness: 0.15,
+    roughness: 0.9
+  });
+  const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = floorY;
+  floor.receiveShadow = true;
+  floorGroup.add(floor);
+
+  const grid = new THREE.GridHelper(280, 56, 0x4a5f8a, 0x2a3a5c);
+  grid.position.y = floorY + 0.04;
+  const gridMaterial = grid.material as THREE.LineBasicMaterial;
+  gridMaterial.transparent = true;
+  gridMaterial.opacity = 0.45;
+  gridMaterial.depthWrite = false;
+  floorGroup.add(grid);
+
+  return floorGroup;
+};
+
+export const createSceneBackground = (scene: THREE.Scene): THREE.Group => {
+  const backgroundGroup = new THREE.Group();
+  backgroundGroup.name = 'sceneBackground';
+
+  backgroundGroup.add(createGradientDome());
+  backgroundGroup.add(createStarField());
+  backgroundGroup.add(createFloor());
+
+  scene.add(backgroundGroup);
+  return backgroundGroup;
+};

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -7,6 +7,7 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import { createExperimentSetup } from '../components/ExperimentSetup';
+import { createSceneBackground } from '../components/SceneBackground';
 import { createSceneLabels } from '../components/SceneLabels';
 import { ParticleSystem } from '../components/ParticleSystem';
 
@@ -96,9 +97,12 @@ export const useThreeScene = () => {
     if (!mountRef.current) return;
 
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x0b0e14);
-    scene.fog = new THREE.Fog(0x0b0e14, 70, 170);
+    // Fallback color behind the gradient dome; fog matches the dome's horizon tone
+    scene.background = new THREE.Color(0x060a14);
+    scene.fog = new THREE.Fog(0x0d1424, 70, 190);
     sceneRef.current = scene;
+
+    createSceneBackground(scene);
 
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.set(-19.165995152477358, 9.637643699188821, 5.055107657476825);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scene backdrop was a flat solid color (`#0b0e14`), which made the experiment feel like it was floating in a void. This PR replaces it with a layered, laboratory-in-space backdrop built in a new `SceneBackground.ts` module:

- **Gradient sky dome**: a large inverted sphere with a custom shader blending three tones (deep zenith, subtle blue horizon band, darker nadir), giving the scene depth without distracting from the experiment.
- **Twinkling star field**: ~700 shader-driven point stars above the horizon with per-star phase and size, animated via a time uniform. Additive blending keeps them subtle under the existing bloom pass.
- **Grid floor**: a dark circular floor plane just below the apparatus that receives shadows from the existing key light, plus a soft blue grid that anchors the setup spatially and gives scale when orbiting.
- Fog color updated to match the dome's horizon tone so distant geometry fades naturally into the backdrop instead of into a mismatched flat color.

All background elements use `depthWrite: false` and negative `renderOrder` where appropriate, so they never occlude the beam, particles, or labels.

## Screenshots

Default camera:

[Default view with new background](https://cursor.com/agents/bc-019f34be-1e14-77b9-9d44-853845faae52/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscene-default.png)

Zoomed out (dome gradient, stars, and grid floor visible):

[Zoomed out view showing dome, stars and grid floor](https://cursor.com/agents/bc-019f34be-1e14-77b9-9d44-853845faae52/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscene-zoomout.png)

## Testing

- `npm run lint` — passes (only pre-existing warnings)
- `npm run build` — passes
- Verified visually via headless Chrome screenshots at default camera and zoomed out

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34be-1e14-77b9-9d44-853845faae52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34be-1e14-77b9-9d44-853845faae52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

