### PR TITLE
Stick blocked particles to the diffraction panel and differentiate proton/electron sizes

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -21,7 +21,8 @@ export class ParticleSystem {
   }
 
   createSingleProton() {
-    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // Protons are drawn larger than electrons to suggest their much greater mass
+    const geometry = new THREE.SphereGeometry(0.1, 12, 8);
     // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
       color: new THREE.Color(0xff5533).multiplyScalar(2.5),
@@ -51,7 +52,8 @@ export class ParticleSystem {
   }
 
   createSingleElectron() {
-    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // Electrons are drawn smaller than protons to suggest their much smaller mass
+    const geometry = new THREE.SphereGeometry(0.05, 12, 8);
     // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
       color: new THREE.Color(0x3388ff).multiplyScalar(2.5),
@@ -129,5 +131,26 @@ export class ParticleSystem {
 
   getParticleCount(): number {
     return this.particles.length;
+  }
+
+  getActiveParticleCount(): number {
+    return this.particles.filter(particle => !particle.userData.isMark).length;
+  }
+
+  // Keeps at most maxMarks stuck particles, removing the oldest ones first
+  limitMarks(maxMarks: number) {
+    const marks = this.particles.filter(particle => particle.userData.isMark);
+    if (marks.length <= maxMarks) return;
+
+    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
+    const marksToRemove = new Set(marks.slice(0, marks.length - maxMarks));
+
+    this.particles = this.particles.filter(particle => {
+      if (marksToRemove.has(particle)) {
+        this.removeParticle(particle);
+        return false;
+      }
+      return true;
+    });
   }
 }

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -60,9 +60,10 @@ export const useExperimentAnimation = ({
       // Update experiment physics  
       const currentPhase = activePhase; // Use prop directly instead of ref
 
-      // Create new particles only in proton/electron/observer phases and if particle system exists
-      if ((currentPhase === 'proton' || currentPhase === 'electron' || currentPhase === 'observer') && particleSystem && particleSystem.getParticleCount() < 120) {
-        const particlesToAdd = Math.min(5, 120 - particleSystem.getParticleCount());
+      // Create new particles only in proton/electron/observer phases and if particle system exists.
+      // Marks stuck on the panels are excluded from the cap so emission never stalls.
+      if ((currentPhase === 'proton' || currentPhase === 'electron' || currentPhase === 'observer') && particleSystem && particleSystem.getActiveParticleCount() < 120) {
+        const particlesToAdd = Math.min(5, 120 - particleSystem.getActiveParticleCount());
         for (let i = 0; i < particlesToAdd; i++) {
           if (currentPhase === 'proton') {
             particleSystem.createSingleProton();
@@ -83,6 +84,9 @@ export const useExperimentAnimation = ({
         );
 
         particleSystem.setParticles(updatedParticles);
+
+        // Keep the number of stuck marks bounded for performance
+        particleSystem.limitMarks(600);
       }
 
       if (composer) {

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -11,6 +11,11 @@ export const updateParticlePhysics = (
   const time = Date.now() * 0.001;
 
   return particles.filter(particle => {
+    // Marks are stuck in place: no physics updates needed
+    if (particle.userData.isMark) {
+      return true;
+    }
+
     // Update particle position
     particle.position.x += particle.userData.velocity.x;
     particle.position.y += particle.userData.velocity.y;
@@ -25,12 +30,22 @@ export const updateParticlePhysics = (
           particle.position.y >= -2 && particle.position.y <= 2));
 
     if (hitsDiffractionPanel) {
-      onRemoveParticle(particle);
-      return false;
+      // Blocked particles stick to the front face of the diffraction panel
+      particle.position.z = 14.75;
+      if (particle.material instanceof THREE.MeshBasicMaterial) {
+        // Dim the HDR color so stuck particles glow less than flying ones
+        particle.material.color.multiplyScalar(0.55);
+      }
+      particle.userData.velocity.x = 0;
+      particle.userData.velocity.y = 0;
+      particle.userData.velocity.z = 0;
+      particle.userData.isMark = true;
+      particle.userData.markTime = time;
+      return true;
     }
 
     // Check hit with detection screen (z=30)
-    if (detectionScreen && !particle.userData.isMark && particle.position.z >= 30 &&
+    if (detectionScreen && particle.position.z >= 30 &&
       Math.abs(particle.position.x) <= 10 && Math.abs(particle.position.y) <= 7.5) {
       if (activePhase === 'electron') {
         // Electrons disappear on detection


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Protons and electrons that do not pass through the slits now stick to the front face of the diffraction panel (the first screen) instead of disappearing. Stuck particles keep their color (red for protons, blue for electrons), slightly dimmed so they glow less than flying particles.
- Improved the visual proportion between protons and electrons: protons are now rendered with radius 0.1 while electrons use radius 0.05, hinting at the much larger proton mass.

## Details

- `physicsSimulation.ts`: on diffraction panel collision, the particle is converted into a stuck mark (zero velocity, snapped to z = 14.75 in front of the panel) instead of being removed. Marks skip physics updates entirely.
- `ParticleSystem.ts`: added `getActiveParticleCount()` (marks excluded) and `limitMarks(maxMarks)` which removes the oldest marks beyond a cap.
- `useExperimentAnimation.ts`: the 120-particle spawn cap now counts only flying particles so emission never stalls as marks accumulate; stuck marks are capped at 600 (oldest removed first) to keep performance stable.

## Testing

- `npm run lint` and `npm run build` pass (only pre-existing warnings).
- Verified in a headless browser: particles accumulate on the diffraction panel in both proton and electron phases, and the size difference between protons and electrons is visible.

[Proton phase with particles stuck on the diffraction panel](https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fproton.png)
[Electron phase with particles stuck on the diffraction panel](https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Felectron.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34c5-41c6-78da-b732-132865e81790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

