### PR TITLE
Stick blocked particles to screens with physically accurate persistence

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -136,4 +136,21 @@ export class ParticleSystem {
   getActiveParticleCount(): number {
     return this.particles.filter(particle => !particle.userData.isMark).length;
   }
+
+  // Safety cap: keeps at most maxMarks stuck particles, consuming the oldest first
+  limitMarks(maxMarks: number) {
+    const marks = this.particles.filter(particle => particle.userData.isMark);
+    if (marks.length <= maxMarks) return;
+
+    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
+    const marksToRemove = new Set(marks.slice(0, marks.length - maxMarks));
+
+    this.particles = this.particles.filter(particle => {
+      if (marksToRemove.has(particle)) {
+        this.removeParticle(particle);
+        return false;
+      }
+      return true;
+    });
+  }
 }

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -136,21 +136,4 @@ export class ParticleSystem {
   getActiveParticleCount(): number {
     return this.particles.filter(particle => !particle.userData.isMark).length;
   }
-
-  // Safety cap: keeps at most maxMarks stuck particles, consuming the oldest first
-  limitMarks(maxMarks: number) {
-    const marks = this.particles.filter(particle => particle.userData.isMark);
-    if (marks.length <= maxMarks) return;
-
-    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
-    const marksToRemove = new Set(marks.slice(0, marks.length - maxMarks));
-
-    this.particles = this.particles.filter(particle => {
-      if (marksToRemove.has(particle)) {
-        this.removeParticle(particle);
-        return false;
-      }
-      return true;
-    });
-  }
 }

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -21,7 +21,8 @@ export class ParticleSystem {
   }
 
   createSingleProton() {
-    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // Protons are drawn larger than electrons to suggest their much greater mass
+    const geometry = new THREE.SphereGeometry(0.1, 12, 8);
     // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
       color: new THREE.Color(0xff5533).multiplyScalar(2.5),
@@ -51,7 +52,8 @@ export class ParticleSystem {
   }
 
   createSingleElectron() {
-    const geometry = new THREE.SphereGeometry(0.06, 12, 8);
+    // Electrons are drawn smaller than protons to suggest their much smaller mass
+    const geometry = new THREE.SphereGeometry(0.05, 12, 8);
     // HDR color (values > 1) so the bloom pass makes particles glow
     const material = new THREE.MeshBasicMaterial({
       color: new THREE.Color(0x3388ff).multiplyScalar(2.5),
@@ -129,5 +131,26 @@ export class ParticleSystem {
 
   getParticleCount(): number {
     return this.particles.length;
+  }
+
+  getActiveParticleCount(): number {
+    return this.particles.filter(particle => !particle.userData.isMark).length;
+  }
+
+  // Keeps at most maxMarks stuck particles, removing the oldest ones first
+  limitMarks(maxMarks: number) {
+    const marks = this.particles.filter(particle => particle.userData.isMark);
+    if (marks.length <= maxMarks) return;
+
+    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
+    const marksToRemove = new Set(marks.slice(0, marks.length - maxMarks));
+
+    this.particles = this.particles.filter(particle => {
+      if (marksToRemove.has(particle)) {
+        this.removeParticle(particle);
+        return false;
+      }
+      return true;
+    });
   }
 }

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -136,21 +136,4 @@ export class ParticleSystem {
   getActiveParticleCount(): number {
     return this.particles.filter(particle => !particle.userData.isMark).length;
   }
-
-  // Keeps at most maxMarks stuck particles, removing the oldest ones first
-  limitMarks(maxMarks: number) {
-    const marks = this.particles.filter(particle => particle.userData.isMark);
-    if (marks.length <= maxMarks) return;
-
-    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
-    const marksToRemove = new Set(marks.slice(0, marks.length - maxMarks));
-
-    this.particles = this.particles.filter(particle => {
-      if (marksToRemove.has(particle)) {
-        this.removeParticle(particle);
-        return false;
-      }
-      return true;
-    });
-  }
 }

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -84,6 +84,11 @@ export const useExperimentAnimation = ({
         );
 
         particleSystem.setParticles(updatedParticles);
+
+        // Safety cap so the scene never accumulates unbounded meshes.
+        // Electron phase keeps many more marks so the interference pattern
+        // can fully build up before older deposits are consumed.
+        particleSystem.limitMarks(currentPhase === 'electron' ? 1200 : 400);
       }
 
       if (composer) {

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -84,9 +84,6 @@ export const useExperimentAnimation = ({
         );
 
         particleSystem.setParticles(updatedParticles);
-
-        // Keep the number of stuck marks bounded for performance
-        particleSystem.limitMarks(600);
       }
 
       if (composer) {

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -16,6 +16,16 @@ interface AnimationProps {
   activePhase: string;
 }
 
+// Total number of particles fired per phase: the source has a finite budget,
+// so deposits on the screens are bounded and never need to be recycled.
+// The electron phase fires many more particles so the interference pattern
+// can build up point by point.
+const PARTICLE_BUDGET: Record<string, number> = {
+  proton: 400,
+  observer: 400,
+  electron: 1500
+};
+
 export const useExperimentAnimation = ({
   scene,
   camera,
@@ -44,6 +54,9 @@ export const useExperimentAnimation = ({
     console.log('Starting animation loop');
 
     let frameCount = 0;
+    // Counts particles fired by the source in the current phase.
+    // Resets whenever the effect re-runs (i.e. on phase change).
+    let emittedCount = 0;
 
     const animate = () => {
       animationIdRef.current = requestAnimationFrame(animate);
@@ -60,16 +73,23 @@ export const useExperimentAnimation = ({
       // Update experiment physics  
       const currentPhase = activePhase; // Use prop directly instead of ref
 
-      // Create new particles only in proton/electron/observer phases and if particle system exists.
-      // Marks stuck on the panels are excluded from the cap so emission never stalls.
-      if ((currentPhase === 'proton' || currentPhase === 'electron' || currentPhase === 'observer') && particleSystem && particleSystem.getActiveParticleCount() < 120) {
-        const particlesToAdd = Math.min(5, 120 - particleSystem.getActiveParticleCount());
+      // Fire new particles only while the finite per-phase budget lasts,
+      // keeping at most 120 particles in flight at once. Marks stuck on the
+      // screens don't count against the in-flight cap.
+      const budget = PARTICLE_BUDGET[currentPhase] ?? 0;
+      if (budget > 0 && particleSystem && emittedCount < budget && particleSystem.getActiveParticleCount() < 120) {
+        const particlesToAdd = Math.min(
+          5,
+          120 - particleSystem.getActiveParticleCount(),
+          budget - emittedCount
+        );
         for (let i = 0; i < particlesToAdd; i++) {
           if (currentPhase === 'proton') {
             particleSystem.createSingleProton();
           } else if (currentPhase === 'electron' || currentPhase === 'observer') {
             particleSystem.createSingleElectron();
           }
+          emittedCount++;
         }
       }
 
@@ -84,11 +104,6 @@ export const useExperimentAnimation = ({
         );
 
         particleSystem.setParticles(updatedParticles);
-
-        // Safety cap so the scene never accumulates unbounded meshes.
-        // Electron phase keeps many more marks so the interference pattern
-        // can fully build up before older deposits are consumed.
-        particleSystem.limitMarks(currentPhase === 'electron' ? 1200 : 400);
       }
 
       if (composer) {

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -60,9 +60,10 @@ export const useExperimentAnimation = ({
       // Update experiment physics  
       const currentPhase = activePhase; // Use prop directly instead of ref
 
-      // Create new particles only in proton/electron/observer phases and if particle system exists
-      if ((currentPhase === 'proton' || currentPhase === 'electron' || currentPhase === 'observer') && particleSystem && particleSystem.getParticleCount() < 120) {
-        const particlesToAdd = Math.min(5, 120 - particleSystem.getParticleCount());
+      // Create new particles only in proton/electron/observer phases and if particle system exists.
+      // Marks stuck on the panels are excluded from the cap so emission never stalls.
+      if ((currentPhase === 'proton' || currentPhase === 'electron' || currentPhase === 'observer') && particleSystem && particleSystem.getActiveParticleCount() < 120) {
+        const particlesToAdd = Math.min(5, 120 - particleSystem.getActiveParticleCount());
         for (let i = 0; i < particlesToAdd; i++) {
           if (currentPhase === 'proton') {
             particleSystem.createSingleProton();
@@ -83,6 +84,9 @@ export const useExperimentAnimation = ({
         );
 
         particleSystem.setParticles(updatedParticles);
+
+        // Keep the number of stuck marks bounded for performance
+        particleSystem.limitMarks(600);
       }
 
       if (composer) {

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -11,6 +11,11 @@ export const updateParticlePhysics = (
   const time = Date.now() * 0.001;
 
   return particles.filter(particle => {
+    // Marks are stuck in place: no physics updates needed
+    if (particle.userData.isMark) {
+      return true;
+    }
+
     // Update particle position
     particle.position.x += particle.userData.velocity.x;
     particle.position.y += particle.userData.velocity.y;
@@ -25,12 +30,22 @@ export const updateParticlePhysics = (
           particle.position.y >= -2 && particle.position.y <= 2));
 
     if (hitsDiffractionPanel) {
-      onRemoveParticle(particle);
-      return false;
+      // Blocked particles stick to the front face of the diffraction panel
+      particle.position.z = 14.75;
+      if (particle.material instanceof THREE.MeshBasicMaterial) {
+        // Dim the HDR color so stuck particles glow less than flying ones
+        particle.material.color.multiplyScalar(0.55);
+      }
+      particle.userData.velocity.x = 0;
+      particle.userData.velocity.y = 0;
+      particle.userData.velocity.z = 0;
+      particle.userData.isMark = true;
+      particle.userData.markTime = time;
+      return true;
     }
 
     // Check hit with detection screen (z=30)
-    if (detectionScreen && !particle.userData.isMark && particle.position.z >= 30 &&
+    if (detectionScreen && particle.position.z >= 30 &&
       Math.abs(particle.position.x) <= 10 && Math.abs(particle.position.y) <= 7.5) {
       if (activePhase === 'electron') {
         // Electrons disappear on detection

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -1,6 +1,16 @@
 import * as THREE from 'three';
 import { Particle } from '../components/ParticleSystem';
 
+// How long stuck marks stay on the screens before being consumed, per phase.
+// Electron marks last until the full interference pattern is realized (60s),
+// matching the pattern build-up animation duration.
+const MARK_LIFETIME_SECONDS: Record<string, number> = {
+  proton: 8,
+  observer: 8,
+  electron: 60
+};
+const MARK_FADE_SECONDS = 2.5;
+
 export const updateParticlePhysics = (
   particles: Particle[],
   detectionScreen: THREE.Mesh | null,
@@ -11,8 +21,22 @@ export const updateParticlePhysics = (
   const time = Date.now() * 0.001;
 
   return particles.filter(particle => {
-    // Marks are stuck in place: no physics updates needed
+    // Stuck marks stay in place, then fade out and get consumed after their lifetime
     if (particle.userData.isMark) {
+      const lifetime = MARK_LIFETIME_SECONDS[activePhase] ?? 8;
+      const age = time - particle.userData.markTime;
+
+      if (age >= lifetime) {
+        onRemoveParticle(particle);
+        return false;
+      }
+
+      const fadeStart = lifetime - MARK_FADE_SECONDS;
+      if (age > fadeStart && particle.material instanceof THREE.MeshBasicMaterial) {
+        particle.material.transparent = true;
+        particle.material.opacity = Math.max(0, 1 - (age - fadeStart) / MARK_FADE_SECONDS);
+        particle.material.needsUpdate = true;
+      }
       return true;
     }
 

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -1,16 +1,6 @@
 import * as THREE from 'three';
 import { Particle } from '../components/ParticleSystem';
 
-// How long stuck marks stay on the screens before being consumed, per phase.
-// Electron marks last until the full interference pattern is realized (60s),
-// matching the pattern build-up animation duration.
-const MARK_LIFETIME_SECONDS: Record<string, number> = {
-  proton: 8,
-  observer: 8,
-  electron: 60
-};
-const MARK_FADE_SECONDS = 2.5;
-
 export const updateParticlePhysics = (
   particles: Particle[],
   detectionScreen: THREE.Mesh | null,
@@ -21,22 +11,8 @@ export const updateParticlePhysics = (
   const time = Date.now() * 0.001;
 
   return particles.filter(particle => {
-    // Stuck marks stay in place, then fade out and get consumed after their lifetime
+    // Stuck marks stay in place permanently (until the phase changes)
     if (particle.userData.isMark) {
-      const lifetime = MARK_LIFETIME_SECONDS[activePhase] ?? 8;
-      const age = time - particle.userData.markTime;
-
-      if (age >= lifetime) {
-        onRemoveParticle(particle);
-        return false;
-      }
-
-      const fadeStart = lifetime - MARK_FADE_SECONDS;
-      if (age > fadeStart && particle.material instanceof THREE.MeshBasicMaterial) {
-        particle.material.transparent = true;
-        particle.material.opacity = Math.max(0, 1 - (age - fadeStart) / MARK_FADE_SECONDS);
-        particle.material.needsUpdate = true;
-      }
       return true;
     }
 

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -47,24 +47,23 @@ export const updateParticlePhysics = (
     // Check hit with detection screen (z=30)
     if (detectionScreen && particle.position.z >= 30 &&
       Math.abs(particle.position.x) <= 10 && Math.abs(particle.position.y) <= 7.5) {
-      if (activePhase === 'electron') {
-        // Electrons disappear on detection
-        onRemoveParticle(particle);
-        return false;
-      } else {
-        // Convert particle to detection mark (proton behavior)
-        particle.position.z = 30;
-        if (particle.material instanceof THREE.MeshBasicMaterial) {
-          // Slightly over-white HDR value so detection marks glow via bloom
+      // All detected particles stick permanently on the screen until the phase changes
+      particle.position.z = 30;
+      if (particle.material instanceof THREE.MeshBasicMaterial) {
+        if (activePhase === 'electron') {
+          // Keep the electron color, slightly dimmed like panel deposits
+          particle.material.color.multiplyScalar(0.65);
+        } else {
+          // Proton / observer detection marks
           particle.material.color.setRGB(1.6, 1.6, 1.5);
         }
-        particle.userData.velocity.x = 0;
-        particle.userData.velocity.y = 0;
-        particle.userData.velocity.z = 0;
-        particle.scale.setScalar(1.2);
-        particle.userData.isMark = true;
-        particle.userData.markTime = time;
       }
+      particle.userData.velocity.x = 0;
+      particle.userData.velocity.y = 0;
+      particle.userData.velocity.z = 0;
+      particle.scale.setScalar(1.2);
+      particle.userData.isMark = true;
+      particle.userData.markTime = time;
     }
 
     // Remove particles that are too far from the experiment area


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The particle source now fires a **finite budget of particles per phase**: 400 for proton/observer, 1500 for electron (more electrons so the interference pattern can build up point by point). Once the budget is exhausted, emission stops.
- Particles blocked by the diffraction panel stick to its front face; particles reaching the detection screen deposit marks (white for proton/observer, blue for electron). **Deposits are permanent** — they never fade or get recycled, and are only cleared when the user switches phase.
- Because the total particle count is finite, the scene stays bounded with no need for mark-recycling caps.
- Improved the visual proportion between protons and electrons: protons are rendered with radius 0.1 vs 0.05 for electrons, hinting at the much larger proton mass.

## Details

- `useExperimentAnimation.ts`: added a per-phase `PARTICLE_BUDGET`; an `emittedCount` counter (reset on phase change) stops emission once the budget is spent, while keeping at most 120 particles in flight at a time.
- `physicsSimulation.ts`: on diffraction panel collision the particle becomes a permanent stuck mark on the panel front face (z = 14.75); detection screen hits become permanent marks in every phase.
- `ParticleSystem.ts`: added `getActiveParticleCount()` (marks excluded) so stuck deposits don't block the in-flight cap.

## Testing

- `npm run lint` and `npm run build` pass (only pre-existing warnings).
- Verified in a headless browser: in the proton phase the particle count plateaus once the budget is exhausted and the scene becomes static with deposits persisting on both screens; in the electron phase deposits keep accumulating toward the larger budget while the interference pattern builds.

[Proton phase after budget exhaustion: static deposits on both screens](https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fproton-final.png)
[Electron phase accumulating deposits toward the larger budget](https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Felectron-final.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34c5-41c6-78da-b732-132865e81790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34c5-41c6-78da-b732-132865e81790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

