### PR TITLE
Rendi bianche le scritte in scena

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -36,8 +36,7 @@ const createTextLabel = (text: string): THREE.Group => {
     map: texture,
     transparent: true,
     opacity: 0.9,
-    // Keep label luminance below the bloom threshold so text doesn't glow
-    color: 0xb9c1cf,
+    color: 0xffffff,
     // Without this the sprite's full quad (including fully transparent pixels)
     // writes to the depth buffer and occludes the additive laser beam drawn
     // afterwards, which shows up as invisible boxes cutting through the beam.

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -57,8 +57,7 @@ const createObserver = (scene: THREE.Scene): THREE.Group => {
     map: texture,
     transparent: true,
     opacity: 0.9,
-    // Keep label luminance below the bloom threshold so text doesn't glow
-    color: 0xb9c1cf,
+    color: 0xffffff,
     depthWrite: false
   });
   const sprite = new THREE.Sprite(spriteMaterial);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Le etichette 3D nella scena (Particle Generator, Diffraction Slits, Detection Screen, Observer) venivano renderizzate con una tinta grigio-blu (`0xb9c1cf`) sul materiale dello sprite, attenuando il testo bianco disegnato sul canvas.

## Changes

- Impostato `color: 0xffffff` nel materiale degli sprite in `SceneLabels.ts`
- Stessa modifica per l'etichetta "Observer" in `useThreeScene.ts`

## Affected labels

- Particle Generator / Proton Accelerator / Laser / Electron Gun
- Diffraction Slits
- Detection Screen
- Observer
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34d5-076a-76c7-99ba-460cd9db4858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34d5-076a-76c7-99ba-460cd9db4858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

