### PR TITLE
Fix detection screen shadow only appearing on frame

### DIFF
--- a/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
+++ b/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
@@ -10,6 +10,7 @@ import { useThreeScene } from './hooks/useThreeScene';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout';
 import { useExperimentAnimation } from './hooks/useExperimentAnimation';
 import { useViewportControl } from './hooks/useViewportControl';
+import { createDetectionScreenBackMaterial } from './components/ExperimentSetup';
 import { updateGeneratorLabel } from './components/SceneLabels';
 
 
@@ -31,10 +32,7 @@ export default function DoubleSlitExperiment() {
     });
     detectionScreenRef.current.material = interferenceMaterial;
 
-    const baseMaterial = new THREE.MeshBasicMaterial({
-      color: 0x333333,
-      side: THREE.DoubleSide
-    });
+    const baseMaterial = createDetectionScreenBackMaterial();
     detectionScreenBackRef.current.material = baseMaterial;
 
     const animate = () => {
@@ -141,10 +139,7 @@ export default function DoubleSlitExperiment() {
       rightTrapezoidRef.current.visible = showLightElements;
       observerRef.current.visible = showObserver;
 
-      const defaultMaterial = new THREE.MeshBasicMaterial({
-        color: 0x333333,
-        side: THREE.DoubleSide
-      });
+      const defaultMaterial = createDetectionScreenBackMaterial();
       detectionScreenBackRef.current.material = defaultMaterial;
 
       const transparentMaterial = new THREE.MeshBasicMaterial({

--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -1,5 +1,13 @@
 import * as THREE from 'three';
 
+export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
+  new THREE.MeshStandardMaterial({
+    color: 0x30343c,
+    metalness: 0.1,
+    roughness: 0.85,
+    side: THREE.DoubleSide
+  });
+
 const createGenerator = (scene: THREE.Scene) => {
   const generatorGroup = new THREE.Group();
 
@@ -65,12 +73,7 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
 
   // Detection screen back (background layer)
   const backGeometry = new THREE.PlaneGeometry(20, 15);
-  const backMaterial = new THREE.MeshStandardMaterial({
-    color: 0x30343c,
-    metalness: 0.1,
-    roughness: 0.85,
-    side: THREE.DoubleSide
-  });
+  const backMaterial = createDetectionScreenBackMaterial();
   const detectionScreenBack = new THREE.Mesh(backGeometry, backMaterial);
   detectionScreenBack.position.set(0, 0, 30.1);
   detectionScreenBack.rotation.x = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The detection screen shadow only appeared on the metallic frame (cornice), not on the full screen surface.

## Root cause

`detectionScreenBack` is created in `ExperimentSetup.ts` with `MeshStandardMaterial` and `receiveShadow = true`, but `DoubleSlitExperiment.tsx` replaced that material with `MeshBasicMaterial` whenever the phase changed. `MeshBasicMaterial` does not receive shadows, while the frame bars kept `MeshStandardMaterial`.

## Fix

- Export a shared `createDetectionScreenBackMaterial()` helper from `ExperimentSetup.ts`
- Use it consistently for the back plane instead of `MeshBasicMaterial`

This restores shadow reception across the entire detection screen surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34db-161a-7814-b1e2-b482f26da679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34db-161a-7814-b1e2-b482f26da679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

