### PR TITLE
Fix detection screen ground shadow only showing on frame

### DIFF
--- a/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
+++ b/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
@@ -10,6 +10,7 @@ import { useThreeScene } from './hooks/useThreeScene';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout';
 import { useExperimentAnimation } from './hooks/useExperimentAnimation';
 import { useViewportControl } from './hooks/useViewportControl';
+import { createDetectionScreenBackMaterial } from './components/ExperimentSetup';
 import { updateGeneratorLabel } from './components/SceneLabels';
 
 
@@ -31,10 +32,7 @@ export default function DoubleSlitExperiment() {
     });
     detectionScreenRef.current.material = interferenceMaterial;
 
-    const baseMaterial = new THREE.MeshBasicMaterial({
-      color: 0x333333,
-      side: THREE.DoubleSide
-    });
+    const baseMaterial = createDetectionScreenBackMaterial();
     detectionScreenBackRef.current.material = baseMaterial;
 
     const animate = () => {
@@ -141,10 +139,7 @@ export default function DoubleSlitExperiment() {
       rightTrapezoidRef.current.visible = showLightElements;
       observerRef.current.visible = showObserver;
 
-      const defaultMaterial = new THREE.MeshBasicMaterial({
-        color: 0x333333,
-        side: THREE.DoubleSide
-      });
+      const defaultMaterial = createDetectionScreenBackMaterial();
       detectionScreenBackRef.current.material = defaultMaterial;
 
       const transparentMaterial = new THREE.MeshBasicMaterial({

--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -71,12 +71,13 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
   detectionScreen.rotation.x = 0;
   scene.add(detectionScreen);
 
-  // Detection screen back (background layer)
-  const backGeometry = new THREE.PlaneGeometry(20, 15);
+  // Detection screen back (background layer) — thin box so it casts a full ground shadow
+  const screenDepth = 0.12;
+  const backGeometry = new THREE.BoxGeometry(20, 15, screenDepth);
   const backMaterial = createDetectionScreenBackMaterial();
   const detectionScreenBack = new THREE.Mesh(backGeometry, backMaterial);
   detectionScreenBack.position.set(0, 0, 30.1);
-  detectionScreenBack.rotation.x = 0;
+  detectionScreenBack.castShadow = true;
   detectionScreenBack.receiveShadow = true;
   scene.add(detectionScreenBack);
 

--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -1,5 +1,13 @@
 import * as THREE from 'three';
 
+export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
+  new THREE.MeshStandardMaterial({
+    color: 0x30343c,
+    metalness: 0.1,
+    roughness: 0.85,
+    side: THREE.DoubleSide
+  });
+
 const createGenerator = (scene: THREE.Scene) => {
   const generatorGroup = new THREE.Group();
 
@@ -65,12 +73,7 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
 
   // Detection screen back (background layer)
   const backGeometry = new THREE.PlaneGeometry(20, 15);
-  const backMaterial = new THREE.MeshStandardMaterial({
-    color: 0x30343c,
-    metalness: 0.1,
-    roughness: 0.85,
-    side: THREE.DoubleSide
-  });
+  const backMaterial = createDetectionScreenBackMaterial();
   const detectionScreenBack = new THREE.Mesh(backGeometry, backMaterial);
   detectionScreenBack.position.set(0, 0, 30.1);
   detectionScreenBack.rotation.x = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the ground, only the metallic frame (cornice) of the detection screen cast a visible shadow — a rectangular outline — but the screen surface itself did not.

## Root cause

Two issues combined:

1. **Only the frame had `castShadow = true`** — the four frame bars are box geometry and cast shadows on the floor, but the main screen panel did not.
2. **The screen panel used `PlaneGeometry`** — a zero-thickness plane often fails to cast shadows in Three.js shadow mapping, even when `castShadow` is enabled.

Additionally, phase changes replaced the back panel material with `MeshBasicMaterial`, which does not receive shadows (fixed separately in #32, now merged into master).

## Fix

- Export and reuse `createDetectionScreenBackMaterial()` so the back panel keeps a PBR material that receives shadows
- Replace the back panel plane with a thin `BoxGeometry(20, 15, 0.12)` and set `castShadow = true`

This produces a full rectangular shadow on the floor matching the 20×15 screen area, not just the frame outline.

## Merge status

Rebased/merged with latest `master` (`e8c7db9`). One simple conflict in `ExperimentSetup.ts` (plane vs thin box for back panel) — resolved by keeping the thin box + `castShadow` approach. No conflicting intents with master's particle persistence (#30) or label color (#31) changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34db-161a-7814-b1e2-b482f26da679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34db-161a-7814-b1e2-b482f26da679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

