### PR TITLE
Electron phase fires continuously without detection-screen dots; proton/observer phases auto-restart

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -111,6 +111,23 @@ export class ParticleSystem {
     this.particles = [];
   }
 
+  // Keeps at most maxMarks stuck deposits, removing the oldest ones first
+  limitMarks(maxMarks: number) {
+    const marks = this.particles.filter(particle => particle.userData.isMark);
+    if (marks.length <= maxMarks) {
+      return;
+    }
+    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
+    const toRemove = new Set(marks.slice(0, marks.length - maxMarks));
+    this.particles = this.particles.filter(particle => {
+      if (toRemove.has(particle)) {
+        this.removeParticle(particle);
+        return false;
+      }
+      return true;
+    });
+  }
+
   clearDetectionMarks() {
     this.particles = this.particles.filter(particle => {
       if (particle.userData.isMark) {

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -16,15 +16,25 @@ interface AnimationProps {
   activePhase: string;
 }
 
-// Total number of particles fired per phase: the source has a finite budget,
-// so deposits on the screens are bounded and never need to be recycled.
-// The electron phase fires many more particles so the interference pattern
-// can build up point by point.
+// Total number of particles fired per phase. Proton and observer phases have
+// a finite budget: once it is exhausted and every particle has landed, the
+// whole phase animation restarts after a short pause. The electron phase
+// fires continuously and never stops.
 const PARTICLE_BUDGET: Record<string, number> = {
-  proton: 400,
-  observer: 400,
-  electron: 1500
+  proton: 800,
+  observer: 800,
+  electron: Infinity
 };
+
+// Maximum particles simultaneously in flight (marks stuck on screens excluded)
+const MAX_IN_FLIGHT = 150;
+
+// Pause between the end of a finite phase and its automatic restart
+const RESTART_DELAY_MS = 3000;
+
+// Cap on deposits stuck to the diffraction panel during the continuous
+// electron phase, so meshes don't accumulate without bound
+const MAX_ELECTRON_MARKS = 600;
 
 export const useExperimentAnimation = ({
   scene,
@@ -57,6 +67,9 @@ export const useExperimentAnimation = ({
     // Counts particles fired by the source in the current phase.
     // Resets whenever the effect re-runs (i.e. on phase change).
     let emittedCount = 0;
+    // Timestamp of when a finite phase ran out of particles, used to
+    // schedule the automatic restart of the phase animation.
+    let phaseEndedAt: number | null = null;
 
     const animate = () => {
       animationIdRef.current = requestAnimationFrame(animate);
@@ -73,14 +86,15 @@ export const useExperimentAnimation = ({
       // Update experiment physics  
       const currentPhase = activePhase; // Use prop directly instead of ref
 
-      // Fire new particles only while the finite per-phase budget lasts,
-      // keeping at most 120 particles in flight at once. Marks stuck on the
+      // Fire new particles while the per-phase budget lasts (the electron
+      // budget is infinite, so electrons are fired continuously), keeping a
+      // bounded number of particles in flight at once. Marks stuck on the
       // screens don't count against the in-flight cap.
       const budget = PARTICLE_BUDGET[currentPhase] ?? 0;
-      if (budget > 0 && particleSystem && emittedCount < budget && particleSystem.getActiveParticleCount() < 120) {
+      if (budget > 0 && particleSystem && emittedCount < budget && particleSystem.getActiveParticleCount() < MAX_IN_FLIGHT) {
         const particlesToAdd = Math.min(
           5,
-          120 - particleSystem.getActiveParticleCount(),
+          MAX_IN_FLIGHT - particleSystem.getActiveParticleCount(),
           budget - emittedCount
         );
         for (let i = 0; i < particlesToAdd; i++) {
@@ -91,6 +105,33 @@ export const useExperimentAnimation = ({
           }
           emittedCount++;
         }
+      }
+
+      // During the continuous electron phase, drop the oldest deposits on the
+      // diffraction panel so they never accumulate without bound.
+      if (currentPhase === 'electron' && particleSystem) {
+        particleSystem.limitMarks(MAX_ELECTRON_MARKS);
+      }
+
+      // Once a finite phase has fired its whole budget and every particle has
+      // landed or left the scene, wait a few seconds and restart the phase
+      // animation from scratch.
+      if (
+        particleSystem &&
+        Number.isFinite(budget) &&
+        budget > 0 &&
+        emittedCount >= budget &&
+        particleSystem.getActiveParticleCount() === 0
+      ) {
+        if (phaseEndedAt === null) {
+          phaseEndedAt = performance.now();
+        } else if (performance.now() - phaseEndedAt >= RESTART_DELAY_MS) {
+          particleSystem.clearAllParticles();
+          emittedCount = 0;
+          phaseEndedAt = null;
+        }
+      } else {
+        phaseEndedAt = null;
       }
 
       // Update particle physics only if particle system exists

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -47,16 +47,16 @@ export const updateParticlePhysics = (
     // Check hit with detection screen (z=30)
     if (detectionScreen && particle.position.z >= 30 &&
       Math.abs(particle.position.x) <= 10 && Math.abs(particle.position.y) <= 7.5) {
-      // All detected particles stick permanently on the screen until the phase changes
+      if (activePhase === 'electron') {
+        // Electrons never leave dots on the detection screen: the interference
+        // pattern building up there is rendered by the screen texture instead.
+        onRemoveParticle(particle);
+        return false;
+      }
+      // Proton / observer particles stick permanently until the phase restarts
       particle.position.z = 30;
       if (particle.material instanceof THREE.MeshBasicMaterial) {
-        if (activePhase === 'electron') {
-          // Keep the electron color, slightly dimmed like panel deposits
-          particle.material.color.multiplyScalar(0.65);
-        } else {
-          // Proton / observer detection marks
-          particle.material.color.setRGB(1.6, 1.6, 1.5);
-        }
+        particle.material.color.setRGB(1.6, 1.6, 1.5);
       }
       particle.userData.velocity.x = 0;
       particle.userData.velocity.y = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Electron phase**
  - Electrons that reach the detection screen are now removed instead of sticking as dots: the detection screen shows only the interference pattern (rendered by the fading-in canvas texture). Discarded electrons still stick only to the first screen (the diffraction panel).
  - Electrons are fired continuously with no budget limit. To keep memory and performance bounded, deposits on the diffraction panel are capped at 600, dropping the oldest ones first.

- **Proton and observer phases**
  - The per-phase particle budget was doubled from 400 to 800 and the in-flight cap raised from 120 to 150, so many more particles are fired.
  - Once the budget is exhausted and every particle has landed or left the scene, the phase waits ~3 seconds, then clears all marks and restarts the whole animation from scratch, looping indefinitely.

## Changes

- `utils/physicsSimulation.ts`: electrons hitting the detection screen are removed instead of becoming permanent marks; proton/observer detection marks unchanged.
- `hooks/useExperimentAnimation.ts`: infinite electron budget, larger proton/observer budget, in-flight cap constant, restart timer for finite phases, and panel-mark capping for the continuous electron phase.
- `components/ParticleSystem.ts`: new `limitMarks(maxMarks)` method that removes the oldest stuck deposits beyond a threshold.

## Verification

- `npx tsc --noEmit`, `npm run lint`, and `npm run build` all pass (only pre-existing lint warnings remain).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f36bf-3129-778f-8082-8340255b138a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f36bf-3129-778f-8082-8340255b138a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

