### PR TITLE
Rimuove il bagliore dalle etichette testuali della scena 3D

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -16,9 +16,6 @@ const createTextLabel = (text: string): THREE.Group => {
   context.font = 'bold 72px Arial';
   context.textAlign = 'center';
   context.textBaseline = 'middle';
-  // Subtle halo only, so labels stay readable without glowing
-  context.shadowColor = 'rgba(140, 190, 255, 0.35)';
-  context.shadowBlur = 6;
 
   const lines = text.split('\n');
   const lineHeight = 90;

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -46,9 +46,6 @@ const createObserver = (scene: THREE.Scene): THREE.Group => {
   context.font = 'bold 72px Arial';
   context.textAlign = 'center';
   context.textBaseline = 'middle';
-  // Subtle halo only, so the label stays readable without glowing
-  context.shadowColor = 'rgba(120, 200, 255, 0.35)';
-  context.shadowBlur = 6;
   context.fillText('Observer', canvas.width / 2, canvas.height / 2);
 
   const texture = new THREE.CanvasTexture(canvas);
@@ -157,7 +154,7 @@ export const useThreeScene = () => {
       new THREE.Vector2(window.innerWidth, window.innerHeight),
       0.55,
       0.4,
-      0.6
+      1.0
     );
     composer.addPass(bloomPass);
     composer.addPass(new OutputPass());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Obiettivo

Rimuovere il bagliore visibile sulle scritte della scena 3D (Particle Generator, Diffraction Slits, Detection Screen, Observer).

## Modifiche

- **Etichette canvas** (`SceneLabels.ts`, `useThreeScene.ts`): rimossi `shadowBlur` e `shadowColor` che creavano un alone blu attorno al testo.
- **Bloom pass** (`useThreeScene.ts`): soglia alzata da `0.6` a `1.0` così il testo bianco standard non viene più illuminato dal post-processing, mentre particelle e altri elementi HDR mantengono il bagliore.

## Risultato atteso

Le etichette appaiono come testo bianco netto, senza alone o bagliore, restando comunque leggibili sullo sfondo scuro.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3701-62bf-7cb7-b68d-a32a8570e575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3701-62bf-7cb7-b68d-a32a8570e575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

