### PR TITLE
Enlarge gun emitter aperture to match laser and particles

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const EMITTER_APERTURE_RADIUS = 2.5;
+
 export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
   new THREE.MeshStandardMaterial({
     color: 0x30343c,
@@ -36,8 +38,8 @@ const createGenerator = (scene: THREE.Scene) => {
     generatorGroup.add(ring);
   });
 
-  // Glowing emitter aperture on the muzzle
-  const apertureGeometry = new THREE.CircleGeometry(1.2, 48);
+  // Glowing emitter aperture on the muzzle — sized to match laser beam and particle spread
+  const apertureGeometry = new THREE.CircleGeometry(EMITTER_APERTURE_RADIUS, 48);
   const apertureMaterial = new THREE.MeshBasicMaterial({
     color: new THREE.Color(0x77bbff).multiplyScalar(1.6)
   });
@@ -45,7 +47,7 @@ const createGenerator = (scene: THREE.Scene) => {
   aperture.position.z = 6.01;
   generatorGroup.add(aperture);
 
-  const apertureRimGeometry = new THREE.TorusGeometry(1.35, 0.12, 16, 48);
+  const apertureRimGeometry = new THREE.TorusGeometry(EMITTER_APERTURE_RADIUS + 0.15, 0.12, 16, 48);
   const apertureRim = new THREE.Mesh(apertureRimGeometry, ringMaterial);
   apertureRim.position.z = 6.0;
   generatorGroup.add(apertureRim);
@@ -158,7 +160,7 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
 
   scene.add(diffractionPanelGroup);
 
-  const beamRadius = 2.5;
+  const beamRadius = EMITTER_APERTURE_RADIUS;
   const beamLength = 15;
   const beamGeometry = new THREE.CylinderGeometry(beamRadius, beamRadius, beamLength, 48, 1, true);
   const beamMaterial = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The inner glowing circle on the gun muzzle (emitter aperture) had radius **1.2**, while the green laser beam uses radius **2.5** and particles spawn over a similar area (±2.25 × ±2.0). This made the laser and particles appear to exit from outside the aperture opening.

## Solution

- Increased the aperture circle from radius 1.2 → **2.5**
- Increased the surrounding rim torus proportionally (2.65 major radius)
- Introduced a shared `EMITTER_APERTURE_RADIUS` constant used by both the aperture geometry and the laser beam cylinder, keeping them aligned

## Files changed

- `src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3708-284e-7cab-ac0c-8cec88aa415c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3708-284e-7cab-ac0c-8cec88aa415c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

