### PR TITLE
Disabilita la selezione del testo su tutto il sito

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,7 @@ body {
   font-family: 'Nimbus Sans', system-ui, sans-serif;
   touch-action: manipulation;
   -webkit-text-size-adjust: none;
+  -webkit-touch-callout: none;
 }
 
 * {
@@ -49,16 +50,5 @@ body {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-/* Allow text selection for specific UI elements */
-.orientation-title,
-.orientation-message,
-.orientation-subtitle,
-.phase-selector button,
-.top-bar * {
-  -webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
+  -webkit-touch-callout: none;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Modifica

Il sito aveva già `user-select: none` applicato globalmente, ma alcune eccezioni CSS riabilitavano la selezione del testo su elementi specifici (top bar, avviso orientamento, pulsanti del phase selector).

## Cosa è cambiato

- Rimosso il blocco CSS che riabilitava `user-select: text` su `.orientation-title`, `.orientation-message`, `.orientation-subtitle`, `.phase-selector button` e `.top-bar *`
- Aggiunto `-webkit-touch-callout: none` su `html`, `body` e tutti gli elementi per bloccare anche la selezione tramite long-press su iOS

Ora nessun testo HTML del sito è selezionabile dall'utente.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f370d-687b-73fc-8376-272fea7129d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f370d-687b-73fc-8376-272fea7129d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

