### PR TITLE
Limita il getto elettronico a un numero finito di particelle

### DIFF
--- a/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
+++ b/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import * as THREE from 'three';
 import './DoubleSlitExperiment.css';
 import PhaseSelector from './components/PhaseSelector/PhaseSelector';
@@ -19,7 +19,7 @@ export default function DoubleSlitExperiment() {
   const phaseStartTime = useRef<number>(0);
   const animationFrameRef = useRef<number>(0);
 
-  const animateElectronPattern = () => {
+  const animateElectronPattern = useCallback(() => {
     if (!detectionScreenRef.current || !detectionScreenBackRef.current) return;
 
     const interferenceTexture = createParticleInterferenceTexture();
@@ -59,7 +59,18 @@ export default function DoubleSlitExperiment() {
     }
 
     animate();
-  };
+  }, [activePhase]);
+
+  const restartElectronPhase = useCallback(() => {
+    phaseStartTime.current = Date.now();
+    animateElectronPattern();
+  }, [animateElectronPattern]);
+
+  const handlePhaseCycleRestart = useCallback((phase: string) => {
+    if (phase === 'electron') {
+      restartElectronPhase();
+    }
+  }, [restartElectronPhase]);
 
   const createParticleInterferenceTexture = (): THREE.CanvasTexture => {
     const canvas = document.createElement('canvas');
@@ -159,8 +170,7 @@ export default function DoubleSlitExperiment() {
         });
         detectionScreenRef.current.material = interferenceMaterial;
       } else if (activePhase === 'electron') {
-        phaseStartTime.current = Date.now();
-        animateElectronPattern();
+        restartElectronPhase();
       }
 
       let labelText = 'Particle Generator';
@@ -180,7 +190,7 @@ export default function DoubleSlitExperiment() {
 
       console.log('Light elements visibility:', showLightElements, 'Observer visibility:', showObserver, 'Generator label:', labelText, 'for phase:', activePhase);
     }
-  }, [activePhase, sceneReady]);
+  }, [activePhase, sceneReady, restartElectronPhase]);
 
   // Cleanup animation on unmount or phase change
   useEffect(() => {
@@ -209,7 +219,8 @@ export default function DoubleSlitExperiment() {
     controls: controlsRef.current,
     particleSystem: particleSystemRef.current,
     detectionScreen: detectionScreenRef.current,
-    activePhase
+    activePhase,
+    onPhaseCycleRestart: handlePhaseCycleRestart
   });
 
 

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -14,16 +14,17 @@ interface AnimationProps {
   particleSystem: ParticleSystem | null;
   detectionScreen: THREE.Mesh | null;
   activePhase: string;
+  onPhaseCycleRestart?: (phase: string) => void;
 }
 
-// Total number of particles fired per phase. Proton and observer phases have
-// a finite budget: once it is exhausted and every particle has landed, the
-// whole phase animation restarts after a short pause. The electron phase
-// fires continuously and never stops.
+// Total number of particles fired per phase. Once the budget is exhausted and
+// every particle has landed, the whole phase animation restarts after a short
+// pause. The electron phase uses a larger budget so the interference pattern
+// fade-in can finish before the cycle restarts.
 const PARTICLE_BUDGET: Record<string, number> = {
   proton: 800,
   observer: 800,
-  electron: Infinity
+  electron: 4800
 };
 
 // Maximum particles simultaneously in flight (marks stuck on screens excluded)
@@ -31,10 +32,6 @@ const MAX_IN_FLIGHT = 150;
 
 // Pause between the end of a finite phase and its automatic restart
 const RESTART_DELAY_MS = 3000;
-
-// Cap on deposits stuck to the diffraction panel during the continuous
-// electron phase, so meshes don't accumulate without bound
-const MAX_ELECTRON_MARKS = 600;
 
 export const useExperimentAnimation = ({
   scene,
@@ -44,7 +41,8 @@ export const useExperimentAnimation = ({
   controls,
   particleSystem,
   detectionScreen,
-  activePhase
+  activePhase,
+  onPhaseCycleRestart
 }: AnimationProps) => {
   const animationIdRef = useRef<number | null>(null);
 
@@ -86,10 +84,9 @@ export const useExperimentAnimation = ({
       // Update experiment physics  
       const currentPhase = activePhase; // Use prop directly instead of ref
 
-      // Fire new particles while the per-phase budget lasts (the electron
-      // budget is infinite, so electrons are fired continuously), keeping a
-      // bounded number of particles in flight at once. Marks stuck on the
-      // screens don't count against the in-flight cap.
+      // Fire new particles while the per-phase budget lasts, keeping a bounded
+      // number of particles in flight at once. Marks stuck on the screens
+      // don't count against the in-flight cap.
       const budget = PARTICLE_BUDGET[currentPhase] ?? 0;
       if (budget > 0 && particleSystem && emittedCount < budget && particleSystem.getActiveParticleCount() < MAX_IN_FLIGHT) {
         const particlesToAdd = Math.min(
@@ -105,12 +102,6 @@ export const useExperimentAnimation = ({
           }
           emittedCount++;
         }
-      }
-
-      // During the continuous electron phase, drop the oldest deposits on the
-      // diffraction panel so they never accumulate without bound.
-      if (currentPhase === 'electron' && particleSystem) {
-        particleSystem.limitMarks(MAX_ELECTRON_MARKS);
       }
 
       // Once a finite phase has fired its whole budget and every particle has
@@ -129,6 +120,7 @@ export const useExperimentAnimation = ({
           particleSystem.clearAllParticles();
           emittedCount = 0;
           phaseEndedAt = null;
+          onPhaseCycleRestart?.(currentPhase);
         }
       } else {
         phaseEndedAt = null;
@@ -161,5 +153,5 @@ export const useExperimentAnimation = ({
         cancelAnimationFrame(animationIdRef.current);
       }
     };
-  }, [scene, camera, renderer, composer, controls, particleSystem, detectionScreen, activePhase]);
+  }, [scene, camera, renderer, composer, controls, particleSystem, detectionScreen, activePhase, onPhaseCycleRestart]);
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

La fase electron usava `Infinity` come budget di particelle, quindi il cannone sparava elettroni senza mai fermarsi. Le altre fasi (proton e observer) avevano invece un budget finito di 800 particelle con riavvio automatico.

## Soluzione

- Impostato il budget electron a **4800 particelle** (6× rispetto alle altre fasi), sufficienti per permettere il completamento dell'animazione di interferenza (fade-in di 60 secondi) prima del riavvio del ciclo.
- Rimosso il limite `MAX_ELECTRON_MARKS` che serviva solo a contenere l'accumulo infinito di segni sul pannello di diffrazione.
- Aggiunto il callback `onPhaseCycleRestart` per riavviare anche l'animazione del pattern di interferenza quando la fase electron si ricicla automaticamente.

## Comportamento

Come per proton e observer: una volta esaurito il budget e atterrati tutti gli elettroni, la fase attende 3 secondi e riparte da capo con un nuovo pattern di interferenza.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f370f-2f04-78d8-9f57-9baeb89e532d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f370f-2f04-78d8-9f57-9baeb89e532d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

