### PR TITLE
Ripulisce la repo da file inutilizzati, log di debug e codice morto

### DIFF
--- a/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
+++ b/src/app/components/DoubleSlitExperiment/DoubleSlitExperiment.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import * as THREE from 'three';
-import './DoubleSlitExperiment.css';
 import PhaseSelector from './components/PhaseSelector/PhaseSelector';
 import TopBar from './components/TopBar/TopBar';
 import OrientationWarning from './components/OrientationWarning/OrientationWarning';
@@ -124,21 +123,13 @@ export default function DoubleSlitExperiment() {
     controlsRef,
     detectionScreenRef,
     detectionScreenBackRef,
-    diffractionPanelRef,
     lightBeamRef,
     leftTrapezoidRef,
     rightTrapezoidRef,
-    labelsRef,
     particleSystemRef,
     observerRef,
     sceneReady
   } = useThreeScene();
-
-  useEffect(() => {
-    if (sceneReady) {
-      console.log('Scene ready, particle system available:', !!particleSystemRef.current);
-    }
-  }, [sceneReady]);
 
   useEffect(() => {
     if (lightBeamRef.current && leftTrapezoidRef.current && rightTrapezoidRef.current && observerRef.current && sceneRef.current && detectionScreenRef.current && detectionScreenBackRef.current) {
@@ -187,8 +178,6 @@ export default function DoubleSlitExperiment() {
           break;
       }
       updateGeneratorLabel(sceneRef.current, labelText);
-
-      console.log('Light elements visibility:', showLightElements, 'Observer visibility:', showObserver, 'Generator label:', labelText, 'for phase:', activePhase);
     }
   }, [activePhase, sceneReady, restartElectronPhase]);
 
@@ -226,35 +215,18 @@ export default function DoubleSlitExperiment() {
 
 
   const handlePhaseChange = (phase: string) => {
-    console.log('Phase changing to:', phase);
-
     setActivePhase(phase);
 
     if (!particleSystemRef.current) {
-      console.log('No particle system available');
       return;
     }
 
-    if (phase === 'lightwave') {
-      console.log('Switching to lightwave: clearing all particles');
-      particleSystemRef.current.clearAllParticles();
-    } else if (phase === 'proton') {
-      console.log('Switching to proton: clearing and restarting');
-      particleSystemRef.current.clearAllParticles();
+    particleSystemRef.current.clearAllParticles();
+
+    if (phase === 'proton') {
       particleSystemRef.current.createInitialProtons(50);
-      console.log('New protons created:', particleSystemRef.current.getParticleCount());
-    } else if (phase === 'electron') {
-      console.log('Switching to electron: clearing and restarting');
-      particleSystemRef.current.clearAllParticles();
+    } else if (phase === 'electron' || phase === 'observer') {
       particleSystemRef.current.createInitialElectrons(50);
-      console.log('New electrons created:', particleSystemRef.current.getParticleCount());
-    } else if (phase === 'observer') {
-      console.log('Switching to observer: clearing and restarting with electrons');
-      particleSystemRef.current.clearAllParticles();
-      particleSystemRef.current.createInitialElectrons(50);
-      console.log('New electrons created for observer phase:', particleSystemRef.current.getParticleCount());
-    } else {
-      particleSystemRef.current.clearAllParticles();
     }
   };
 

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -8,7 +8,6 @@ export interface Particle extends THREE.Mesh {
       z: number;
     };
     isMark: boolean;
-    markTime: number;
   };
 }
 
@@ -42,8 +41,7 @@ export class ParticleSystem {
         y: (Math.random() - 0.5) * 0.1,
         z: 0.5 + Math.random() * 0.1
       },
-      isMark: false,
-      markTime: 0
+      isMark: false
     };
 
     this.scene.add(proton);
@@ -73,8 +71,7 @@ export class ParticleSystem {
         y: (Math.random() - 0.5) * 0.1,
         z: 0.5 + Math.random() * 0.1
       },
-      isMark: false,
-      markTime: 0
+      isMark: false
     };
 
     this.scene.add(electron);
@@ -109,33 +106,6 @@ export class ParticleSystem {
       this.removeParticle(particle);
     });
     this.particles = [];
-  }
-
-  // Keeps at most maxMarks stuck deposits, removing the oldest ones first
-  limitMarks(maxMarks: number) {
-    const marks = this.particles.filter(particle => particle.userData.isMark);
-    if (marks.length <= maxMarks) {
-      return;
-    }
-    marks.sort((a, b) => a.userData.markTime - b.userData.markTime);
-    const toRemove = new Set(marks.slice(0, marks.length - maxMarks));
-    this.particles = this.particles.filter(particle => {
-      if (toRemove.has(particle)) {
-        this.removeParticle(particle);
-        return false;
-      }
-      return true;
-    });
-  }
-
-  clearDetectionMarks() {
-    this.particles = this.particles.filter(particle => {
-      if (particle.userData.isMark) {
-        this.removeParticle(particle);
-        return false;
-      }
-      return true;
-    });
   }
 
   getParticles(): Particle[] {

--- a/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneLabels.ts
@@ -49,29 +49,22 @@ const createTextLabel = (text: string): THREE.Group => {
   return labelGroup;
 };
 
-export const createSceneLabels = (scene: THREE.Scene): THREE.Group[] => {
-  const labels: THREE.Group[] = [];
-
+export const createSceneLabels = (scene: THREE.Scene): void => {
   const generatorLabel = createTextLabel('Particle Generator');
   generatorLabel.position.set(0, 4.5, 0);
   generatorLabel.scale.setScalar(2);
   generatorLabel.name = 'generatorLabel';
   scene.add(generatorLabel);
-  labels.push(generatorLabel);
 
   const diffractionSlitLabel = createTextLabel('Diffraction Slits');
   diffractionSlitLabel.position.set(0, 8.5, 15);
   diffractionSlitLabel.scale.setScalar(2);
   scene.add(diffractionSlitLabel);
-  labels.push(diffractionSlitLabel);
 
   const detectionScreenLabel = createTextLabel('Detection Screen');
   detectionScreenLabel.position.set(0, 8.5, 30);
   detectionScreenLabel.scale.setScalar(2);
   scene.add(detectionScreenLabel);
-  labels.push(detectionScreenLabel);
-
-  return labels;
 };
 
 export const updateGeneratorLabel = (scene: THREE.Scene, newText: string) => {
@@ -88,18 +81,4 @@ export const updateGeneratorLabel = (scene: THREE.Scene, newText: string) => {
     const newSprite = newLabelGroup.children[0];
     generatorLabel.add(newSprite);
   }
-};
-
-export const cleanupLabels = (scene: THREE.Scene | null, labels: THREE.Group[]) => {
-  labels.forEach(labelGroup => {
-    if (scene) {
-      scene.remove(labelGroup);
-    }
-    labelGroup.children.forEach(child => {
-      if (child instanceof THREE.Sprite && child.material.map) {
-        child.material.map.dispose();
-        child.material.dispose();
-      }
-    });
-  });
 };

--- a/src/app/components/DoubleSlitExperiment/components/TopBar/TopBar.css
+++ b/src/app/components/DoubleSlitExperiment/components/TopBar/TopBar.css
@@ -1,2 +1,0 @@
-/* TopBar styles - currently using Tailwind classes in component */
-/* If needed, custom styles for the TopBar can be added here */

--- a/src/app/components/DoubleSlitExperiment/components/TopBar/TopBar.tsx
+++ b/src/app/components/DoubleSlitExperiment/components/TopBar/TopBar.tsx
@@ -1,8 +1,6 @@
-import './TopBar.css';
-
 export default function TopBar() {
   return (
-    <div className="top-bar absolute top-0 left-0 right-0 bg-black/40 p-4 flex justify-between items-center z-10" style={{ fontFamily: 'Nimbus Sans, system-ui, sans-serif' }}>
+    <div className="absolute top-0 left-0 right-0 bg-black/40 p-4 flex justify-between items-center z-10" style={{ fontFamily: 'Nimbus Sans, system-ui, sans-serif' }}>
       <div>
         <h1 className="text-white text-lg font-semibold">DOUBLE SLIT EXPERIMENT</h1>
         <p className="text-white text-sm opacity-75">Simulation by Asyntes</p>

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -47,21 +47,10 @@ export const useExperimentAnimation = ({
   const animationIdRef = useRef<number | null>(null);
 
   useEffect(() => {
-    console.log('useExperimentAnimation - Dependencies:', {
-      scene: !!scene,
-      camera: !!camera,
-      renderer: !!renderer,
-      particleSystem: !!particleSystem,
-      sceneChildren: scene?.children.length
-    });
     if (!scene || !camera || !renderer) {
-      console.log('Animation hook missing basic deps, skipping');
       return;
     }
 
-    console.log('Starting animation loop');
-
-    let frameCount = 0;
     // Counts particles fired by the source in the current phase.
     // Resets whenever the effect re-runs (i.e. on phase change).
     let emittedCount = 0;
@@ -71,11 +60,6 @@ export const useExperimentAnimation = ({
 
     const animate = () => {
       animationIdRef.current = requestAnimationFrame(animate);
-
-      frameCount++;
-      if (frameCount % 60 === 0) { // Log every 60 frames (roughly 1 second)
-        console.log('Animation running - Frame:', frameCount, 'Particles:', particleSystem?.getParticleCount() || 0);
-      }
 
       if (controls) {
         controls.update();

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -81,11 +81,9 @@ export const useThreeScene = () => {
   const controlsRef = useRef<OrbitControls | null>(null);
   const detectionScreenRef = useRef<THREE.Mesh | null>(null);
   const detectionScreenBackRef = useRef<THREE.Mesh | null>(null);
-  const diffractionPanelRef = useRef<THREE.Group | null>(null);
   const lightBeamRef = useRef<THREE.Mesh | null>(null);
   const leftTrapezoidRef = useRef<THREE.Mesh | null>(null);
   const rightTrapezoidRef = useRef<THREE.Mesh | null>(null);
-  const labelsRef = useRef<THREE.Group[]>([]);
   const particleSystemRef = useRef<ParticleSystem | null>(null);
   const observerRef = useRef<THREE.Group | null>(null);
 
@@ -171,16 +169,14 @@ export const useThreeScene = () => {
     controls.maxDistance = 60;
     controlsRef.current = controls;
 
-    const { detectionScreen, detectionScreenBack, diffractionPanelGroup, lightBeam, leftTrapezoid, rightTrapezoid } = createExperimentSetup(scene);
+    const { detectionScreen, detectionScreenBack, lightBeam, leftTrapezoid, rightTrapezoid } = createExperimentSetup(scene);
     detectionScreenRef.current = detectionScreen;
     detectionScreenBackRef.current = detectionScreenBack;
-    diffractionPanelRef.current = diffractionPanelGroup;
     lightBeamRef.current = lightBeam;
     leftTrapezoidRef.current = leftTrapezoid;
     rightTrapezoidRef.current = rightTrapezoid;
 
-    const labels = createSceneLabels(scene);
-    labelsRef.current = labels;
+    createSceneLabels(scene);
 
     const particleSystem = new ParticleSystem(scene);
     particleSystemRef.current = particleSystem;
@@ -210,11 +206,9 @@ export const useThreeScene = () => {
     controlsRef,
     detectionScreenRef,
     detectionScreenBackRef,
-    diffractionPanelRef,
     lightBeamRef,
     leftTrapezoidRef,
     rightTrapezoidRef,
-    labelsRef,
     particleSystemRef,
     observerRef,
     sceneReady

--- a/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/physicsSimulation.ts
@@ -8,8 +8,6 @@ export const updateParticlePhysics = (
   onRemoveParticle: (particle: Particle) => void,
   activePhase: string = 'proton'
 ): Particle[] => {
-  const time = Date.now() * 0.001;
-
   return particles.filter(particle => {
     // Stuck marks stay in place permanently (until the phase changes)
     if (particle.userData.isMark) {
@@ -40,7 +38,6 @@ export const updateParticlePhysics = (
       particle.userData.velocity.y = 0;
       particle.userData.velocity.z = 0;
       particle.userData.isMark = true;
-      particle.userData.markTime = time;
       return true;
     }
 
@@ -63,7 +60,6 @@ export const updateParticlePhysics = (
       particle.userData.velocity.z = 0;
       particle.scale.setScalar(1.2);
       particle.userData.isMark = true;
-      particle.userData.markTime = time;
     }
 
     // Remove particles that are too far from the experiment area

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Double Slit Experiment",
@@ -61,9 +50,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cosa cambia

Pulizia della repo da residui temporanei e codice inutilizzato. Nessun cambiamento funzionale.

### File eliminati
- `DoubleSlitExperiment.css` — file completamente vuoto (rimosso anche l'import)
- `TopBar.css` — conteneva solo commenti placeholder, nessuna regola CSS (rimosso anche l'import)

### Boilerplate di create-next-app
- Rimossi i font Google **Geist** e **Geist Mono** da `layout.tsx`: le variabili CSS `--font-geist-*` non erano referenziate da nessuna parte (il sito usa Nimbus Sans definito in `globals.css`)

### Log di debug temporanei
- Rimossi tutti i `console.log` di debug da `DoubleSlitExperiment.tsx` e `useExperimentAnimation.ts`, incluso l'effect che serviva solo a loggare `sceneReady` e il contatore `frameCount` usato solo per il log periodico

### Codice morto
- `cleanupLabels` in `SceneLabels.ts` — esportata ma mai chiamata
- `limitMarks` e `clearDetectionMarks` in `ParticleSystem.ts` — metodi mai invocati
- Campo `markTime` di `Particle` — veniva solo scritto, l'unico lettore era `limitMarks`
- Ref `diffractionPanelRef` e `labelsRef` in `useThreeScene` — restituiti dal hook ma mai letti dal consumer
- Classe `top-bar` nel markup di `TopBar.tsx` — non definita in nessun foglio di stile

### Verificato
- Nessuno screenshot o asset temporaneo tracciato: `banner.png` è usato nei metadati Open Graph e i font `.otf` in `globals.css`
- `tsc --noEmit`, `npm run lint` e `npm run build` passano (restano solo 3 warning `react-hooks/exhaustive-deps` preesistenti)

Bilancio: **+11 / −133 righe**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3727-d0ee-7673-9e05-81816dc10362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3727-d0ee-7673-9e05-81816dc10362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

