### PR TITLE
Lift generator to clear floor without breaking particle alignment

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -5,8 +5,16 @@ const EMITTER_APERTURE_RADIUS = 2.5;
 /** Generator sits at z = -5; the muzzle aperture is at local z ≈ 6. */
 export const GENERATOR_GROUP_Z = -5;
 export const EMITTER_APERTURE_LOCAL_Z = 6.01;
-export const EMITTER_WORLD_Z = GENERATOR_GROUP_Z + EMITTER_APERTURE_LOCAL_Z;
 export const SCENE_FLOOR_Y = -7.6;
+
+/** Must match the rear vessel radius in createGeneratorRearAssembly. */
+export const REAR_VESSEL_RADIUS = 14;
+
+/** Lifts the generator so the vessel underside meets the floor plane. */
+export const MACHINE_LIFT_Y = SCENE_FLOOR_Y + REAR_VESSEL_RADIUS;
+
+export const EMITTER_WORLD_Y = MACHINE_LIFT_Y;
+export const EMITTER_WORLD_Z = GENERATOR_GROUP_Z + EMITTER_APERTURE_LOCAL_Z;
 
 export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
   new THREE.MeshStandardMaterial({
@@ -21,14 +29,17 @@ export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial 
 // penetrate below the floor plane.
 const createGeneratorRearAssembly = (
   bodyMaterial: THREE.MeshStandardMaterial,
-  ringMaterial: THREE.MeshStandardMaterial
+  ringMaterial: THREE.MeshStandardMaterial,
+  machineLiftY: number
 ): THREE.Group => {
   const rearGroup = new THREE.Group();
 
   const BARREL_RADIUS = 3.5;
-  const VESSEL_RADIUS = 14;
+  const VESSEL_RADIUS = REAR_VESSEL_RADIUS;
   const VESSEL_LENGTH = 40;
   const CONE_LENGTH = 6.5;
+
+  const worldToLocalY = (worldY: number) => worldY - machineLiftY;
 
   const BARREL_BACK_Z = -6;
   const CONE_BACK_Z = BARREL_BACK_Z - CONE_LENGTH;
@@ -121,9 +132,9 @@ const createGeneratorRearAssembly = (
   endCap.rotation.x = -Math.PI / 2;
   endCap.position.z = END_CAP_Z;
 
-  // Side legs: floor up to the vessel equator — three stations along the hull
-  const legHeight = -SCENE_FLOOR_Y;
-  const legCenterY = SCENE_FLOOR_Y + legHeight / 2;
+  // Side legs: floor up to the vessel equator (world y = machineLiftY)
+  const legHeight = machineLiftY - SCENE_FLOOR_Y;
+  const legCenterY = worldToLocalY(SCENE_FLOOR_Y + legHeight / 2);
   [-18, -32.5, -46].forEach(z => {
     [-1, 1].forEach(side => {
       addMesh(
@@ -166,13 +177,13 @@ const createGeneratorRearAssembly = (
   const cabinetZ = VESSEL_BACK_Z - 14;
   addMesh(
     new THREE.Mesh(new THREE.BoxGeometry(12, cabinetHeight, 5.5), darkMetalMaterial)
-  ).position.set(0, SCENE_FLOOR_Y + cabinetHeight / 2, cabinetZ);
+  ).position.set(0, worldToLocalY(SCENE_FLOOR_Y + cabinetHeight / 2), cabinetZ);
 
   const cabinetPanel = new THREE.Mesh(
     new THREE.PlaneGeometry(4.5, 1.0),
     new THREE.MeshBasicMaterial({ color: new THREE.Color(0x77bbff).multiplyScalar(1.2) })
   );
-  cabinetPanel.position.set(-6.01, SCENE_FLOOR_Y + 6.5, cabinetZ);
+  cabinetPanel.position.set(-6.01, worldToLocalY(SCENE_FLOOR_Y + 6.5), cabinetZ);
   cabinetPanel.rotation.y = -Math.PI / 2;
   rearGroup.add(cabinetPanel);
 
@@ -183,7 +194,7 @@ const createGeneratorRearAssembly = (
         color: new THREE.Color(i === 2 ? 0x33ff77 : 0xffaa33).multiplyScalar(1.4)
       })
     );
-    led.position.set(-6.01, SCENE_FLOOR_Y + 4.8, cabinetZ + z);
+    led.position.set(-6.01, worldToLocalY(SCENE_FLOOR_Y + 4.8), cabinetZ + z);
     led.rotation.y = -Math.PI / 2;
     rearGroup.add(led);
   });
@@ -194,13 +205,13 @@ const createGeneratorRearAssembly = (
       new THREE.Vector3(0.9, coronaCenterY, VESSEL_CENTER_Z - 2),
       new THREE.Vector3(cableOutset, coronaCenterY - 1.2, VESSEL_CENTER_Z - 8),
       new THREE.Vector3(cableOutset + 0.4, VESSEL_RADIUS * 0.25, VESSEL_BACK_Z - 4),
-      new THREE.Vector3(2, SCENE_FLOOR_Y + 7.5, cabinetZ)
+      new THREE.Vector3(2, worldToLocalY(SCENE_FLOOR_Y + 7.5), cabinetZ)
     ],
     [
       new THREE.Vector3(-0.9, coronaCenterY, VESSEL_CENTER_Z - 2),
       new THREE.Vector3(-cableOutset, coronaCenterY - 1.4, VESSEL_CENTER_Z - 8),
       new THREE.Vector3(-(cableOutset + 0.4), VESSEL_RADIUS * 0.2, VESSEL_BACK_Z - 4),
-      new THREE.Vector3(-2, SCENE_FLOOR_Y + 7.5, cabinetZ)
+      new THREE.Vector3(-2, worldToLocalY(SCENE_FLOOR_Y + 7.5), cabinetZ)
     ]
   ];
   cablePaths.forEach(points => {
@@ -239,7 +250,7 @@ const createGenerator = (scene: THREE.Scene) => {
     generatorGroup.add(ring);
   });
 
-  generatorGroup.add(createGeneratorRearAssembly(bodyMaterial, ringMaterial));
+  generatorGroup.add(createGeneratorRearAssembly(bodyMaterial, ringMaterial, MACHINE_LIFT_Y));
 
   // Glowing emitter aperture on the muzzle — sized to match laser beam and particle spread
   const apertureGeometry = new THREE.CircleGeometry(EMITTER_APERTURE_RADIUS, 48);
@@ -255,7 +266,7 @@ const createGenerator = (scene: THREE.Scene) => {
   apertureRim.position.z = 6.0;
   generatorGroup.add(apertureRim);
 
-  generatorGroup.position.set(0, 0, GENERATOR_GROUP_Z);
+  generatorGroup.position.set(0, MACHINE_LIFT_Y, GENERATOR_GROUP_Z);
   scene.add(generatorGroup);
   return generatorGroup;
 };
@@ -376,7 +387,7 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
   });
   const lightBeam = new THREE.Mesh(beamGeometry, beamMaterial);
 
-  lightBeam.position.set(0, 0, EMITTER_WORLD_Z + beamLength / 2);
+  lightBeam.position.set(0, EMITTER_WORLD_Y, EMITTER_WORLD_Z + beamLength / 2);
   lightBeam.rotation.x = Math.PI / 2;
   lightBeam.visible = false;
   lightBeam.renderOrder = 1;

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { EMITTER_WORLD_Z } from './ExperimentSetup';
+import { EMITTER_WORLD_Y, EMITTER_WORLD_Z } from './ExperimentSetup';
 
 export interface Particle extends THREE.Mesh {
   userData: {
@@ -33,7 +33,7 @@ export class ParticleSystem {
     const spawnZ = EMITTER_WORLD_Z + Math.random() * 0.08;
     proton.position.set(
       (Math.random() - 0.5) * 4.5,
-      (Math.random() - 0.5) * 4.0,
+      EMITTER_WORLD_Y + (Math.random() - 0.5) * 4.0,
       spawnZ
     );
 
@@ -64,7 +64,7 @@ export class ParticleSystem {
     const spawnZ = EMITTER_WORLD_Z + Math.random() * 0.08;
     electron.position.set(
       (Math.random() - 0.5) * 4.5,
-      (Math.random() - 0.5) * 4.0,
+      EMITTER_WORLD_Y + (Math.random() - 0.5) * 4.0,
       spawnZ
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

With vessel radius 14 the hull extended to y = −14 while the floor is at −7.6, so the machine visibly pierced the ground plane from below.

The generator is now lifted by `MACHINE_LIFT_Y = SCENE_FLOOR_Y + REAR_VESSEL_RADIUS` so the vessel underside sits exactly on the floor. To avoid repeating the #42 alignment bug:

- **Particles** spawn at `EMITTER_WORLD_Y` (not y = 0)
- **Laser beam** positioned at `EMITTER_WORLD_Y`
- **Cabinet, legs and cables** use `worldToLocalY()` so floor-relative objects stay on the ground after the lift

## Verification

- `tsc` and `next build` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3716-e721-7f13-a94e-de60179f0f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3716-e721-7f13-a94e-de60179f0f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

