### PR TITLE
Revert massive rear vessel scale and generator lift

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -5,16 +5,8 @@ const EMITTER_APERTURE_RADIUS = 2.5;
 /** Generator sits at z = -5; the muzzle aperture is at local z ≈ 6. */
 export const GENERATOR_GROUP_Z = -5;
 export const EMITTER_APERTURE_LOCAL_Z = 6.01;
-export const SCENE_FLOOR_Y = -7.6;
-
-/** Must match the rear vessel radius in createGeneratorRearAssembly. */
-export const REAR_VESSEL_RADIUS = 14;
-
-/** Lifts the generator so the vessel underside meets the floor plane. */
-export const MACHINE_LIFT_Y = SCENE_FLOOR_Y + REAR_VESSEL_RADIUS;
-
-export const EMITTER_WORLD_Y = MACHINE_LIFT_Y;
 export const EMITTER_WORLD_Z = GENERATOR_GROUP_Z + EMITTER_APERTURE_LOCAL_Z;
+export const SCENE_FLOOR_Y = -7.6;
 
 export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
   new THREE.MeshStandardMaterial({
@@ -29,17 +21,14 @@ export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial 
 // penetrate below the floor plane.
 const createGeneratorRearAssembly = (
   bodyMaterial: THREE.MeshStandardMaterial,
-  ringMaterial: THREE.MeshStandardMaterial,
-  machineLiftY: number
+  ringMaterial: THREE.MeshStandardMaterial
 ): THREE.Group => {
   const rearGroup = new THREE.Group();
 
   const BARREL_RADIUS = 3.5;
-  const VESSEL_RADIUS = REAR_VESSEL_RADIUS;
-  const VESSEL_LENGTH = 40;
-  const CONE_LENGTH = 6.5;
-
-  const worldToLocalY = (worldY: number) => worldY - machineLiftY;
+  const VESSEL_RADIUS = 9;
+  const VESSEL_LENGTH = 24;
+  const CONE_LENGTH = 4.5;
 
   const BARREL_BACK_Z = -6;
   const CONE_BACK_Z = BARREL_BACK_Z - CONE_LENGTH;
@@ -95,9 +84,9 @@ const createGeneratorRearAssembly = (
   vessel.rotation.x = Math.PI / 2;
   vessel.position.z = VESSEL_CENTER_Z;
 
-  [-16, -24, -40, -48].forEach(offset => {
+  [-13, -20, -30, -36].forEach(offset => {
     const ring = addMesh(
-      new THREE.Mesh(new THREE.TorusGeometry(VESSEL_RADIUS + 0.1, 0.38, 16, 88), ringMaterial)
+      new THREE.Mesh(new THREE.TorusGeometry(VESSEL_RADIUS + 0.08, 0.28, 16, 80), ringMaterial)
     );
     ring.position.z = offset;
   });
@@ -111,9 +100,9 @@ const createGeneratorRearAssembly = (
   flange.rotation.x = Math.PI / 2;
   flange.position.z = FLANGE_Z;
 
-  const boltGeometry = new THREE.CylinderGeometry(0.22, 0.22, 0.9, 12);
-  for (let i = 0; i < 22; i++) {
-    const angle = (i / 22) * Math.PI * 2;
+  const boltGeometry = new THREE.CylinderGeometry(0.18, 0.18, 0.8, 12);
+  for (let i = 0; i < 18; i++) {
+    const angle = (i / 18) * Math.PI * 2;
     const bolt = addMesh(new THREE.Mesh(boltGeometry, darkMetalMaterial));
     bolt.rotation.x = Math.PI / 2;
     bolt.position.set(
@@ -132,91 +121,91 @@ const createGeneratorRearAssembly = (
   endCap.rotation.x = -Math.PI / 2;
   endCap.position.z = END_CAP_Z;
 
-  // Side legs: floor up to the vessel equator (world y = machineLiftY)
-  const legHeight = machineLiftY - SCENE_FLOOR_Y;
-  const legCenterY = worldToLocalY(SCENE_FLOOR_Y + legHeight / 2);
-  [-18, -32.5, -46].forEach(z => {
+  // Side legs: floor (y = SCENE_FLOOR_Y) up to the vessel equator (y = 0)
+  const legHeight = -SCENE_FLOOR_Y;
+  const legCenterY = SCENE_FLOOR_Y + legHeight / 2;
+  [-14, -30].forEach(z => {
     [-1, 1].forEach(side => {
       addMesh(
-        new THREE.Mesh(new THREE.BoxGeometry(1.4, legHeight, 2.2), darkMetalMaterial)
-      ).position.set(side * (VESSEL_RADIUS + 0.65), legCenterY, z);
+        new THREE.Mesh(new THREE.BoxGeometry(1.1, legHeight, 1.8), darkMetalMaterial)
+      ).position.set(side * (VESSEL_RADIUS + 0.55), legCenterY, z);
     });
   });
 
   const crownFlange = addMesh(
-    new THREE.Mesh(new THREE.CylinderGeometry(4.2, 4.2, 0.45, 48), ringMaterial)
+    new THREE.Mesh(new THREE.CylinderGeometry(2.8, 2.8, 0.35, 40), ringMaterial)
   );
-  crownFlange.position.set(0, VESSEL_RADIUS + 0.2, VESSEL_CENTER_Z);
+  crownFlange.position.set(0, VESSEL_RADIUS + 0.175, VESSEL_CENTER_Z);
 
-  const bushingBaseY = VESSEL_RADIUS + 0.42;
+  const bushingBaseY = VESSEL_RADIUS + 0.35;
   addMesh(
-    new THREE.Mesh(new THREE.CylinderGeometry(2.0, 2.0, 7.2, 32), darkMetalMaterial)
-  ).position.set(0, bushingBaseY + 3.6, VESSEL_CENTER_Z);
+    new THREE.Mesh(new THREE.CylinderGeometry(1.4, 1.4, 5.5, 32), darkMetalMaterial)
+  ).position.set(0, bushingBaseY + 2.75, VESSEL_CENTER_Z);
 
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < 6; i++) {
     addMesh(
-      new THREE.Mesh(new THREE.CylinderGeometry(3.4, 3.4, 0.45, 48), ceramicMaterial)
-    ).position.set(0, bushingBaseY + 0.45 + i * 0.95, VESSEL_CENTER_Z);
+      new THREE.Mesh(new THREE.CylinderGeometry(2.4, 2.4, 0.4, 48), ceramicMaterial)
+    ).position.set(0, bushingBaseY + 0.4 + i * 0.85, VESSEL_CENTER_Z);
   }
 
-  const topDiscY = bushingBaseY + 0.45 + 6 * 0.95;
-  const coronaRadius = 3.2;
-  const coronaCenterY = topDiscY + 0.225 + coronaRadius + 0.15;
+  const topDiscY = bushingBaseY + 0.4 + 5 * 0.85;
+  const coronaRadius = 2.2;
+  const coronaCenterY = topDiscY + 0.2 + coronaRadius + 0.12;
   addMesh(
     new THREE.Mesh(new THREE.SphereGeometry(coronaRadius, 40, 28), bodyMaterial)
   ).position.set(0, coronaCenterY, VESSEL_CENTER_Z);
 
   const statusLight = new THREE.Mesh(
-    new THREE.SphereGeometry(0.32, 20, 16),
+    new THREE.SphereGeometry(0.26, 20, 16),
     new THREE.MeshBasicMaterial({ color: new THREE.Color(0xffaa33).multiplyScalar(1.5) })
   );
-  statusLight.position.set(0, coronaCenterY + 0.45, VESSEL_CENTER_Z - coronaRadius - 0.35);
+  statusLight.position.set(0, coronaCenterY + 0.35, VESSEL_CENTER_Z - coronaRadius - 0.3);
   rearGroup.add(statusLight);
 
-  const cabinetHeight = 9;
-  const cabinetZ = VESSEL_BACK_Z - 14;
+  const cabinetHeight = 6;
+  const cabinetZ = VESSEL_BACK_Z - 12;
   addMesh(
-    new THREE.Mesh(new THREE.BoxGeometry(12, cabinetHeight, 5.5), darkMetalMaterial)
-  ).position.set(0, worldToLocalY(SCENE_FLOOR_Y + cabinetHeight / 2), cabinetZ);
+    new THREE.Mesh(new THREE.BoxGeometry(8, cabinetHeight, 4), darkMetalMaterial)
+  ).position.set(0, SCENE_FLOOR_Y + cabinetHeight / 2, cabinetZ);
 
   const cabinetPanel = new THREE.Mesh(
-    new THREE.PlaneGeometry(4.5, 1.0),
+    new THREE.PlaneGeometry(3.2, 0.8),
     new THREE.MeshBasicMaterial({ color: new THREE.Color(0x77bbff).multiplyScalar(1.2) })
   );
-  cabinetPanel.position.set(-6.01, worldToLocalY(SCENE_FLOOR_Y + 6.5), cabinetZ);
+  cabinetPanel.position.set(-4.01, SCENE_FLOOR_Y + 4.8, cabinetZ);
   cabinetPanel.rotation.y = -Math.PI / 2;
   rearGroup.add(cabinetPanel);
 
-  [-1.2, 0, 1.2].forEach((z, i) => {
+  [-1, 0, 1].forEach((z, i) => {
     const led = new THREE.Mesh(
-      new THREE.CircleGeometry(0.15, 16),
+      new THREE.CircleGeometry(0.13, 16),
       new THREE.MeshBasicMaterial({
         color: new THREE.Color(i === 2 ? 0x33ff77 : 0xffaa33).multiplyScalar(1.4)
       })
     );
-    led.position.set(-6.01, worldToLocalY(SCENE_FLOOR_Y + 4.8), cabinetZ + z);
+    led.position.set(-4.01, SCENE_FLOOR_Y + 3.6, cabinetZ + z);
     led.rotation.y = -Math.PI / 2;
     rearGroup.add(led);
   });
 
-  const cableOutset = VESSEL_RADIUS + 1.5;
+  const cableOutset = VESSEL_RADIUS + 1.2;
   const cablePaths: THREE.Vector3[][] = [
     [
-      new THREE.Vector3(0.9, coronaCenterY, VESSEL_CENTER_Z - 2),
-      new THREE.Vector3(cableOutset, coronaCenterY - 1.2, VESSEL_CENTER_Z - 8),
-      new THREE.Vector3(cableOutset + 0.4, VESSEL_RADIUS * 0.25, VESSEL_BACK_Z - 4),
-      new THREE.Vector3(2, worldToLocalY(SCENE_FLOOR_Y + 7.5), cabinetZ)
+      new THREE.Vector3(0.7, coronaCenterY, VESSEL_CENTER_Z - 1.2),
+      new THREE.Vector3(cableOutset, coronaCenterY - 0.8, VESSEL_CENTER_Z - 5),
+      new THREE.Vector3(cableOutset, VESSEL_RADIUS * 0.3, VESSEL_BACK_Z - 3),
+      new THREE.Vector3(1.5, SCENE_FLOOR_Y + 5, cabinetZ)
     ],
     [
-      new THREE.Vector3(-0.9, coronaCenterY, VESSEL_CENTER_Z - 2),
-      new THREE.Vector3(-cableOutset, coronaCenterY - 1.4, VESSEL_CENTER_Z - 8),
-      new THREE.Vector3(-(cableOutset + 0.4), VESSEL_RADIUS * 0.2, VESSEL_BACK_Z - 4),
-      new THREE.Vector3(-2, worldToLocalY(SCENE_FLOOR_Y + 7.5), cabinetZ)
+      new THREE.Vector3(-0.7, coronaCenterY, VESSEL_CENTER_Z - 1.2),
+      new THREE.Vector3(-cableOutset, coronaCenterY - 1, VESSEL_CENTER_Z - 5),
+      new THREE.Vector3(-cableOutset, VESSEL_RADIUS * 0.25, VESSEL_BACK_Z - 3),
+      new THREE.Vector3(-1.5, SCENE_FLOOR_Y + 5, cabinetZ)
     ]
   ];
   cablePaths.forEach(points => {
     const curve = new THREE.CatmullRomCurve3(points);
-    addMesh(new THREE.Mesh(new THREE.TubeGeometry(curve, 48, 0.3, 12), cableMaterial));
+    addMesh(new THREE.Mesh(new THREE.TubeGeometry(curve, 40, 0.24, 12), cableMaterial));
   });
 
   return rearGroup;
@@ -250,7 +239,7 @@ const createGenerator = (scene: THREE.Scene) => {
     generatorGroup.add(ring);
   });
 
-  generatorGroup.add(createGeneratorRearAssembly(bodyMaterial, ringMaterial, MACHINE_LIFT_Y));
+  generatorGroup.add(createGeneratorRearAssembly(bodyMaterial, ringMaterial));
 
   // Glowing emitter aperture on the muzzle — sized to match laser beam and particle spread
   const apertureGeometry = new THREE.CircleGeometry(EMITTER_APERTURE_RADIUS, 48);
@@ -266,7 +255,7 @@ const createGenerator = (scene: THREE.Scene) => {
   apertureRim.position.z = 6.0;
   generatorGroup.add(apertureRim);
 
-  generatorGroup.position.set(0, MACHINE_LIFT_Y, GENERATOR_GROUP_Z);
+  generatorGroup.position.set(0, 0, GENERATOR_GROUP_Z);
   scene.add(generatorGroup);
   return generatorGroup;
 };
@@ -387,7 +376,7 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
   });
   const lightBeam = new THREE.Mesh(beamGeometry, beamMaterial);
 
-  lightBeam.position.set(0, EMITTER_WORLD_Y, EMITTER_WORLD_Z + beamLength / 2);
+  lightBeam.position.set(0, 0, EMITTER_WORLD_Z + beamLength / 2);
   lightBeam.rotation.x = Math.PI / 2;
   lightBeam.visible = false;
   lightBeam.renderOrder = 1;

--- a/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ParticleSystem.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { EMITTER_WORLD_Y, EMITTER_WORLD_Z } from './ExperimentSetup';
+import { EMITTER_WORLD_Z } from './ExperimentSetup';
 
 export interface Particle extends THREE.Mesh {
   userData: {
@@ -33,7 +33,7 @@ export class ParticleSystem {
     const spawnZ = EMITTER_WORLD_Z + Math.random() * 0.08;
     proton.position.set(
       (Math.random() - 0.5) * 4.5,
-      EMITTER_WORLD_Y + (Math.random() - 0.5) * 4.0,
+      (Math.random() - 0.5) * 4.0,
       spawnZ
     );
 
@@ -64,7 +64,7 @@ export class ParticleSystem {
     const spawnZ = EMITTER_WORLD_Z + Math.random() * 0.08;
     electron.position.set(
       (Math.random() - 0.5) * 4.5,
-      EMITTER_WORLD_Y + (Math.random() - 0.5) * 4.0,
+      (Math.random() - 0.5) * 4.0,
       spawnZ
     );
 

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -154,12 +154,12 @@ export const useThreeScene = () => {
     keyLight.target.position.set(0, 0, 15);
     keyLight.castShadow = true;
     keyLight.shadow.mapSize.set(2048, 2048);
-    keyLight.shadow.camera.left = -80;
-    keyLight.shadow.camera.right = 80;
-    keyLight.shadow.camera.top = 80;
-    keyLight.shadow.camera.bottom = -80;
+    keyLight.shadow.camera.left = -60;
+    keyLight.shadow.camera.right = 60;
+    keyLight.shadow.camera.top = 60;
+    keyLight.shadow.camera.bottom = -60;
     keyLight.shadow.camera.near = 1;
-    keyLight.shadow.camera.far = 200;
+    keyLight.shadow.camera.far = 160;
     keyLight.shadow.bias = -0.0004;
     scene.add(keyLight);
     scene.add(keyLight.target);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The last dimension changes (PR #44 massive vessel r=14 × length 40, PR #45 floor lift via `MACHINE_LIFT_Y`) raised the entire generator too high and were not desired.

## Solution
Revert `ExperimentSetup.ts`, `ParticleSystem.ts`, and `useThreeScene.ts` to the state after PR #43:

- Rear vessel: **r=9, length 24** (instead of r=14, length 40)
- Generator back at **y=0** — no `MACHINE_LIFT_Y` lift
- Particles and laser beam spawn at the original Y (no `EMITTER_WORLD_Y`)
- Shadow camera bounds restored to pre-massive values

## Verification
- `npm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3716-e721-7f13-a94e-de60179f0f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3716-e721-7f13-a94e-de60179f0f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

