### PR TITLE
Remove blue glow around diffraction slits

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -337,30 +337,6 @@ export const createExperimentSetup = (scene: THREE.Scene) => {
   addPanel(1, 4, 0, 0);
   addPanel(8.5, 4, 5.75, 0);
 
-  // Emissive edging that outlines the two slits
-  const slitEdgeMaterial = new THREE.MeshBasicMaterial({
-    color: new THREE.Color(0x55aaff).multiplyScalar(1.4)
-  });
-  [-1, 1].forEach(slitCenterX => {
-    const slitFrame = new THREE.Group();
-    const edgeSize = 0.06;
-    const verticalEdge = new THREE.BoxGeometry(edgeSize, 4, panelDepth + 0.02);
-    const horizontalEdge = new THREE.BoxGeometry(1 + edgeSize * 2, edgeSize, panelDepth + 0.02);
-    const edges: Array<[THREE.BoxGeometry, number, number]> = [
-      [verticalEdge, -0.5 - edgeSize / 2, 0],
-      [verticalEdge, 0.5 + edgeSize / 2, 0],
-      [horizontalEdge, 0, 2 + edgeSize / 2],
-      [horizontalEdge, 0, -2 - edgeSize / 2]
-    ];
-    edges.forEach(([geometry, x, y]) => {
-      const edge = new THREE.Mesh(geometry, slitEdgeMaterial);
-      edge.position.set(x, y, 0);
-      slitFrame.add(edge);
-    });
-    slitFrame.position.set(slitCenterX, 0, 15);
-    diffractionPanelGroup.add(slitFrame);
-  });
-
   scene.add(diffractionPanelGroup);
 
   const beamRadius = EMITTER_APERTURE_RADIUS;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the emissive blue edging that outlined the two diffraction slits in the 3D scene.

## Changes

- Deleted the `slitEdgeMaterial` meshes and frame geometry in `ExperimentSetup.ts` that created the internal blue glow around each slit opening.

## Result

The slits now appear as plain openings in the diffraction panel, without the bright blue outline effect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7140375f-78b0-4513-b818-7d09e585c37d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7140375f-78b0-4513-b818-7d09e585c37d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

