### PR TITLE
Extend barrel to floor edge; fix emitter glow interference

### DIFF
--- a/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
+++ b/src/app/components/DoubleSlitExperiment/components/ExperimentSetup.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { SCENE_FLOOR_GRID_HALF } from './SceneBackground';
 
 const EMITTER_APERTURE_RADIUS = 2.5;
 
@@ -7,9 +8,9 @@ export const GENERATOR_GROUP_Z = -5;
 export const EMITTER_APERTURE_LOCAL_Z = 6.01;
 export const EMITTER_WORLD_Z = GENERATOR_GROUP_Z + EMITTER_APERTURE_LOCAL_Z;
 
-/** Must match `scene.fog.near` in useThreeScene — barrel tail fades into the horizon. */
-const FOG_NEAR = 70;
-const BARREL_BACK_LOCAL_Z = -(FOG_NEAR - GENERATOR_GROUP_Z - 12);
+/** Barrel tail reaches the back edge of the floor grid plane. */
+const BARREL_BACK_WORLD_Z = -SCENE_FLOOR_GRID_HALF;
+const BARREL_BACK_LOCAL_Z = BARREL_BACK_WORLD_Z - GENERATOR_GROUP_Z;
 
 export const createDetectionScreenBackMaterial = (): THREE.MeshStandardMaterial =>
   new THREE.MeshStandardMaterial({
@@ -23,7 +24,8 @@ const createGenerator = (scene: THREE.Scene) => {
   const generatorGroup = new THREE.Group();
 
   const barrelLength = EMITTER_APERTURE_LOCAL_Z - BARREL_BACK_LOCAL_Z;
-  const bodyGeometry = new THREE.CylinderGeometry(3.5, 3.5, barrelLength, 48);
+  // Open-ended so the muzzle face does not z-fight with the glow disc
+  const bodyGeometry = new THREE.CylinderGeometry(3.5, 3.5, barrelLength, 48, 1, true);
   const bodyMaterial = new THREE.MeshStandardMaterial({
     color: 0xd8dde6,
     metalness: 0.6,
@@ -41,7 +43,12 @@ const createGenerator = (scene: THREE.Scene) => {
     metalness: 0.65,
     roughness: 0.55
   });
-  [-4.5, -1.5, 1.5, 4.5, -14, -26, -38, -50].forEach(offset => {
+  const ringSpacing = 12;
+  const ringOffsets: number[] = [-4.5, -1.5, 1.5, 4.5];
+  for (let z = -16; z >= BARREL_BACK_LOCAL_Z + 4; z -= ringSpacing) {
+    ringOffsets.push(z);
+  }
+  ringOffsets.forEach(offset => {
     const ring = new THREE.Mesh(new THREE.TorusGeometry(3.55, 0.18, 16, 64), ringMaterial);
     ring.position.z = offset;
     ring.castShadow = true;
@@ -53,19 +60,23 @@ const createGenerator = (scene: THREE.Scene) => {
   tailRing.castShadow = true;
   generatorGroup.add(tailRing);
 
-  // Glowing emitter aperture on the muzzle — sized to match laser beam and particle spread
-  const apertureGeometry = new THREE.CircleGeometry(EMITTER_APERTURE_RADIUS, 48);
-  const apertureMaterial = new THREE.MeshBasicMaterial({
-    color: new THREE.Color(0x77bbff).multiplyScalar(1.6)
-  });
-  const aperture = new THREE.Mesh(apertureGeometry, apertureMaterial);
-  aperture.position.z = 6.01;
-  generatorGroup.add(aperture);
-
   const apertureRimGeometry = new THREE.TorusGeometry(EMITTER_APERTURE_RADIUS + 0.15, 0.12, 16, 48);
   const apertureRim = new THREE.Mesh(apertureRimGeometry, ringMaterial);
   apertureRim.position.z = 6.0;
   generatorGroup.add(apertureRim);
+
+  // Glow disc sits slightly in front of the rim; no depth write avoids mesh interference
+  const apertureGeometry = new THREE.CircleGeometry(EMITTER_APERTURE_RADIUS * 0.92, 48);
+  const apertureMaterial = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(0x77bbff).multiplyScalar(1.2),
+    transparent: true,
+    opacity: 0.85,
+    depthWrite: false
+  });
+  const aperture = new THREE.Mesh(apertureGeometry, apertureMaterial);
+  aperture.position.z = 6.14;
+  aperture.renderOrder = 2;
+  generatorGroup.add(aperture);
 
   generatorGroup.position.set(0, 0, GENERATOR_GROUP_Z);
   scene.add(generatorGroup);

--- a/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 
 /** Half-extent of the floor grid in world X/Z — barrel tail aligns with this edge. */
 export const SCENE_FLOOR_GRID_HALF = 140;
+/** Camera pan limit on ±X and ±Z (half the floor grid). */
+export const SCENE_FLOOR_PAN_HALF = SCENE_FLOOR_GRID_HALF / 2;
 export const SCENE_FLOOR_Y = -7.6;
 
 const createGradientDome = (): THREE.Mesh => {

--- a/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
+++ b/src/app/components/DoubleSlitExperiment/components/SceneBackground.ts
@@ -1,5 +1,9 @@
 import * as THREE from 'three';
 
+/** Half-extent of the floor grid in world X/Z — barrel tail aligns with this edge. */
+export const SCENE_FLOOR_GRID_HALF = 140;
+export const SCENE_FLOOR_Y = -7.6;
+
 const createGradientDome = (): THREE.Mesh => {
   const geometry = new THREE.SphereGeometry(400, 32, 24);
   const material = new THREE.ShaderMaterial({
@@ -104,7 +108,7 @@ const createStarField = (): THREE.Points => {
 
 const createFloor = (): THREE.Group => {
   const floorGroup = new THREE.Group();
-  const floorY = -7.6;
+  const floorY = SCENE_FLOOR_Y;
 
   const floorGeometry = new THREE.CircleGeometry(150, 64);
   const floorMaterial = new THREE.MeshStandardMaterial({
@@ -118,7 +122,7 @@ const createFloor = (): THREE.Group => {
   floor.receiveShadow = true;
   floorGroup.add(floor);
 
-  const grid = new THREE.GridHelper(280, 56, 0x4a5f8a, 0x2a3a5c);
+  const grid = new THREE.GridHelper(SCENE_FLOOR_GRID_HALF * 2, 56, 0x4a5f8a, 0x2a3a5c);
   grid.position.y = floorY + 0.04;
   const gridMaterial = grid.material as THREE.LineBasicMaterial;
   gridMaterial.transparent = true;

--- a/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useExperimentAnimation.ts
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { ParticleSystem } from '../components/ParticleSystem';
 import { updateParticlePhysics } from '../utils/physicsSimulation';
+import { clampOrbitControlsPan } from '../utils/clampOrbitControlsPan';
 
 interface AnimationProps {
   scene: THREE.Scene | null;
@@ -63,6 +64,7 @@ export const useExperimentAnimation = ({
 
       if (controls) {
         controls.update();
+        clampOrbitControlsPan(controls);
       }
 
       // Update experiment physics  

--- a/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
+++ b/src/app/components/DoubleSlitExperiment/hooks/useThreeScene.ts
@@ -11,6 +11,7 @@ import { createSceneBackground } from '../components/SceneBackground';
 import { createSceneLabels } from '../components/SceneLabels';
 import { ParticleSystem } from '../components/ParticleSystem';
 import { disposeSceneResources } from '../utils/disposeThreeResources';
+import { clampOrbitControlsPan } from '../utils/clampOrbitControlsPan';
 
 const createObserver = (scene: THREE.Scene): THREE.Group => {
   const observerGroup = new THREE.Group();
@@ -195,6 +196,7 @@ export const useThreeScene = () => {
     controls.dampingFactor = 0.06;
     controls.minDistance = 1;
     controls.maxDistance = 60;
+    clampOrbitControlsPan(controls);
     controlsRef.current = controls;
 
     const { detectionScreen, detectionScreenBack, lightBeam, leftTrapezoid, rightTrapezoid } = createExperimentSetup(scene);

--- a/src/app/components/DoubleSlitExperiment/utils/clampOrbitControlsPan.ts
+++ b/src/app/components/DoubleSlitExperiment/utils/clampOrbitControlsPan.ts
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { SCENE_FLOOR_PAN_HALF } from '../components/SceneBackground';
+
+/** Keeps orbit target (and camera) inside half the floor extent on ±X and ±Z. */
+export const clampOrbitControlsPan = (controls: OrbitControls): void => {
+  const target = controls.target;
+  const camera = controls.object;
+
+  const clampedX = THREE.MathUtils.clamp(target.x, -SCENE_FLOOR_PAN_HALF, SCENE_FLOOR_PAN_HALF);
+  const clampedZ = THREE.MathUtils.clamp(target.z, -SCENE_FLOOR_PAN_HALF, SCENE_FLOOR_PAN_HALF);
+  const dx = clampedX - target.x;
+  const dz = clampedZ - target.z;
+
+  if (dx === 0 && dz === 0) return;
+
+  target.x = clampedX;
+  target.z = clampedZ;
+  camera.position.x += dx;
+  camera.position.z += dz;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extends the generator barrel further backward so its tail reaches the back edge of the floor grid plane (`z = -140` world space).
- Distributes reinforcement rings along the longer tube.
- Fixes blue emitter glow z-fighting with the muzzle mesh.
- Limits camera panning to half the floor extent on ±X and ±Z (±70 world units).

## Changes

**Barrel length**
- Replaced fog-based tail calculation with alignment to `SCENE_FLOOR_GRID_HALF` (140), so the tube visually runs to the end of the floor plane.
- Added shared floor constants in `SceneBackground.ts`.

**Emitter glow**
- Cylinder is now open-ended at the muzzle (no end cap fighting the glow).
- Blue disc is slightly smaller, softer, positioned in front of the metal rim, with `depthWrite: false` and `renderOrder: 2`.

**Camera pan limits**
- New `clampOrbitControlsPan` utility clamps the orbit target (and camera) to `SCENE_FLOOR_PAN_HALF` (70) on both horizontal axes.
- Applied on init and every frame after `controls.update()`.

## Test plan

- [x] `npm run build` passes
- [ ] Visually confirm barrel extends to the back of the floor grid
- [ ] Visually confirm no flickering/interference on the blue emission circle at the muzzle
- [ ] Pan the camera in all four directions and confirm it stops at half the floor edge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-799d290a-3124-45f0-b337-60e96457efda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-799d290a-3124-45f0-b337-60e96457efda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

